### PR TITLE
feat(baywatch): drive-bay health & locator for the Gen9 fleet

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -63,3 +63,17 @@ tasks:
     cmds:
       - docker build -t ghcr.io/andrei-iacobb/truenas-exporter:latest .
       - docker push ghcr.io/andrei-iacobb/truenas-exporter:latest
+
+  monitoring:build-baywatch:
+    desc: Build and push the BayWatch UI image (static Go, no Docker needed via ko)
+    dir: '{{.ROOT_DIR}}/apps/baywatch/ui'
+    cmds:
+      - KO_DOCKER_REPO=ghcr.io/andrei-iacobb/baywatch ko build --bare -t latest --platform=linux/amd64 .
+
+  baywatch:deploy-agents:
+    desc: Cross-compile bw-agent and (re)install it on both Proxmox hosts
+    dir: '{{.ROOT_DIR}}/apps/baywatch'
+    cmds:
+      - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o /tmp/bw-agent ./agent
+      - for ip in 192.168.1.150 192.168.1.100; do scp -q /tmp/bw-agent deploy/baywatch-agent.service deploy/install-agent.sh root@$ip:/tmp/; done
+      - echo "Now run install-agent.sh on each host with BW_TOKEN + BW_CONTROLLER set (see apps/baywatch/README.md)"

--- a/apps/baywatch/README.md
+++ b/apps/baywatch/README.md
@@ -1,0 +1,67 @@
+# BayWatch
+
+Self-hosted drive-bay health & locator for the HPE Gen9 fleet (DL380 + DL360,
+Smart HBA H240 / P440ar in HBA mode). Live LED-accurate chassis view, ZFS + SMART
+health, click-to-locate. Design doc: `../../docs/drivebay-dashboard-plan.html`.
+
+## Why two tiers
+
+The LED hardware (`/sys/class/enclosure`, SES) lives on the **bare-metal Proxmox
+hosts**. The Kubernetes cluster is Talos VMs on those hosts, so a pod cannot touch
+the hardware. Hence:
+
+```
+browser ──https──▶ bw-ui (K8s pod, baywatch.iacob.uk)
+                     │  LAN, token-auth
+            ┌────────┴────────┐
+       bw-agent @DL380   bw-agent @DL360   (systemd, root, bare metal)
+       owns SES+health+LEDs
+```
+
+If bw-ui dies, the agents keep driving the health LEDs. The agent is the **single
+writer** of every caddy LED (it replaces the old `drive-health-leds.timer`).
+
+## Components
+
+- `agent/` - `bw-agent`, a dependency-free static Go daemon. Reconcile loop reads
+  SES sysfs + `zpool status` + `smartctl`, drives the amber fault LED (ZFS not
+  ONLINE / errors, or SMART failing) and the blue locate LED (time-boxed), writing
+  sysfs only on change. Serves REST + SSE on `:9099` with bearer-token auth.
+- `ui/` - `bw-ui`, a static Go binary that aggregates both agents over the LAN,
+  serves the embedded SVG-chassis frontend (`ui/static/index.html`), fans changes
+  to browsers over SSE, and proxies time-boxed locate requests.
+- `deploy/` - systemd unit + `install-agent.sh` (retires the old timer, installs
+  the agent with the shared token).
+
+## API (agent)
+
+| Method | Path | |
+|---|---|---|
+| GET | `/v1/healthz` | unauthenticated liveness |
+| GET | `/v1/enclosures` | full snapshot |
+| GET | `/v1/stream` | SSE: initial snapshot + per-slot deltas |
+| POST | `/v1/locate` | `{enclosure_id, slot, seconds}` time-boxed; 0 = clear |
+
+bw-ui mirrors these under `/api/fleet`, `/api/stream`, `/api/locate` (+ `host`).
+
+## Build & deploy
+
+```sh
+# UI image (no Docker needed):
+task monitoring:build-baywatch
+
+# Agents onto both Proxmox hosts:
+task baywatch:deploy-agents
+# then, on each host (shared token must match the K8s secret):
+BW_TOKEN=<shared> BW_CONTROLLER="Smart HBA H240 x3 + H240ar" bash /tmp/install-agent.sh   # DL380
+BW_TOKEN=<shared> BW_CONTROLLER="Smart Array P440ar (HBA mode)" bash /tmp/install-agent.sh # DL360
+```
+
+The K8s deploy lives in `kubernetes/apps/monitoring/baywatch/`. The shared bearer
+token is in `secret.sops.yaml` (`BW_TOKEN`); the same value is in each host's
+`/etc/baywatch/agent.env`. Rotate by updating both.
+
+## Config (agent env)
+
+`BW_BIND` `:9099` · `BW_TOKEN` · `BW_HOST_LABEL` · `BW_CONTROLLER` · `BW_POLL` 3s ·
+`BW_SMART_POLL` 60s · `BW_LOCATE_DEFAULT` 120 · `BW_LOCATE_MAX` 600.

--- a/apps/baywatch/agent/go.mod
+++ b/apps/baywatch/agent/go.mod
@@ -1,0 +1,3 @@
+module github.com/andrei-iacobb/baywatch/agent
+
+go 1.24

--- a/apps/baywatch/agent/health.go
+++ b/apps/baywatch/agent/health.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"bufio"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// driveHealth is the evaluated health + identity of one block device.
+type driveHealth struct {
+	Zfs      string // ONLINE|DEGRADED|FAULTED|UNAVAIL|OFFLINE|REMOVED or "" if not in a pool
+	Pool     string // pool name ("" if not a member)
+	ZfsErr   bool   // nonzero read/write/cksum error counters
+	SmartStr string // PASSED|FAILED|OK|"" (overall SMART health)
+	SmartOK  bool   // true if SMART is not failing (or unknown)
+	TempC    int    // temperature in C (0 if unknown)
+	Model    string // drive model
+	Serial   string // drive serial
+	Size     string // human size, e.g. 1.6T
+}
+
+// bad reports whether this drive should light its amber fault LED.
+func (h driveHealth) bad() (bool, string) {
+	if h.Zfs != "" && h.Zfs != "ONLINE" {
+		return true, "zfs:" + h.Zfs
+	}
+	if h.ZfsErr {
+		return true, "zfs:errors"
+	}
+	if !h.SmartOK {
+		return true, "smart-fail"
+	}
+	return false, ""
+}
+
+// healthCache holds the latest SMART results (refreshed on a slow timer) and
+// recomputes fast ZFS state on demand. SMART is expensive (spins the bus, ~100ms
+// to seconds per drive); ZFS state is cheap. So the reconcile loop gets fresh
+// ZFS every cycle but reuses cached SMART/temp.
+type healthCache struct {
+	mu    sync.RWMutex
+	smart map[string]smartResult // dev -> last SMART read
+}
+
+type smartResult struct {
+	str    string
+	ok     bool
+	tempC  int
+	model  string
+	serial string
+	size   string
+}
+
+func newHealthCache() *healthCache {
+	return &healthCache{smart: map[string]smartResult{}}
+}
+
+// snapshot returns the merged ZFS+SMART health for every dev seen this cycle.
+func (hc *healthCache) snapshot(devs []string) map[string]driveHealth {
+	zfs := zpoolState()
+	hc.mu.RLock()
+	defer hc.mu.RUnlock()
+	out := make(map[string]driveHealth, len(devs))
+	for _, dev := range devs {
+		if dev == "" {
+			continue
+		}
+		dh := driveHealth{SmartOK: true} // default optimistic until SMART says otherwise
+		if z, ok := zfs[dev]; ok {
+			dh.Zfs = z.state
+			dh.Pool = z.pool
+			dh.ZfsErr = z.errs
+		}
+		if s, ok := hc.smart[dev]; ok {
+			dh.SmartStr = s.str
+			dh.SmartOK = s.ok
+			dh.TempC = s.tempC
+			dh.Model = s.model
+			dh.Serial = s.serial
+			dh.Size = s.size
+		}
+		out[dev] = dh
+	}
+	return out
+}
+
+// refreshSmart re-reads SMART health + temperature for each dev. Runs on the
+// slow timer in its own goroutine.
+func (hc *healthCache) refreshSmart(devs []string) {
+	fresh := make(map[string]smartResult, len(devs))
+	for _, dev := range devs {
+		if dev == "" {
+			continue
+		}
+		fresh[dev] = readSmart(dev)
+	}
+	hc.mu.Lock()
+	hc.smart = fresh
+	hc.mu.Unlock()
+}
+
+func readSmart(dev string) smartResult {
+	res := smartResult{ok: true}
+	if out, err := exec.Command("lsblk", "-dno", "SIZE", "/dev/"+dev).Output(); err == nil {
+		res.size = strings.TrimSpace(string(out))
+	}
+	out, _ := exec.Command("smartctl", "-i", "-H", "-A", "/dev/"+dev).CombinedOutput()
+	sc := bufio.NewScanner(strings.NewReader(string(out)))
+	for sc.Scan() {
+		line := sc.Text()
+		l := strings.ToLower(line)
+		switch {
+		case res.model == "" && (strings.HasPrefix(l, "device model") || strings.HasPrefix(l, "product:") || strings.HasPrefix(l, "model number")):
+			res.model = afterColon(line)
+		case res.serial == "" && (strings.HasPrefix(l, "serial number") || strings.HasPrefix(l, "serial number:")):
+			res.serial = afterColon(line)
+		case strings.Contains(l, "overall-health") || strings.Contains(l, "smart health status"):
+			// "SMART overall-health self-assessment test result: PASSED"
+			// "SMART Health Status: OK"
+			if i := strings.LastIndex(line, ":"); i >= 0 {
+				res.str = strings.TrimSpace(line[i+1:])
+			}
+			res.ok = !strings.Contains(l, "fail")
+		case strings.Contains(l, "current drive temperature"):
+			// SAS: "Current Drive Temperature: 34 C"
+			res.tempC = firstInt(line)
+		case strings.HasPrefix(strings.TrimSpace(line), "194") && strings.Contains(l, "temperature"):
+			// SATA attr 194 Temperature_Celsius ... <raw value at end>
+			if v := lastInt(line); v > 0 && v < 120 {
+				res.tempC = v
+			}
+		case res.tempC == 0 && strings.HasPrefix(strings.TrimSpace(line), "190") && strings.Contains(l, "temperature"):
+			if v := lastInt(line); v > 0 && v < 120 {
+				res.tempC = v
+			}
+		}
+	}
+	return res
+}
+
+type zfsLeaf struct {
+	pool  string
+	state string
+	errs  bool
+}
+
+// zpoolState parses `zpool status -P` and maps each leaf vdev to its base block
+// device, pool, state, and whether it has any error counters. Drives not in a
+// pool (e.g. passthrough to a VM) simply do not appear.
+func zpoolState() map[string]zfsLeaf {
+	out := map[string]zfsLeaf{}
+	b, err := exec.Command("zpool", "status", "-P").Output()
+	if err != nil {
+		return out
+	}
+	var pool string
+	sc := bufio.NewScanner(strings.NewReader(string(b)))
+	for sc.Scan() {
+		line := sc.Text()
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "pool:") {
+			pool = strings.TrimSpace(strings.TrimPrefix(trimmed, "pool:"))
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "/dev/") {
+			continue
+		}
+		f := strings.Fields(trimmed)
+		if len(f) < 2 {
+			continue
+		}
+		base := baseDev(f[0])
+		if base == "" {
+			continue
+		}
+		leaf := zfsLeaf{pool: pool, state: f[1]}
+		if len(f) >= 5 {
+			r := atoi(f[2])
+			w := atoi(f[3])
+			c := atoi(f[4])
+			leaf.errs = r > 0 || w > 0 || c > 0
+		}
+		out[base] = leaf
+	}
+	return out
+}
+
+// baseDev resolves a zpool leaf path (often /dev/disk/by-id/... or /dev/sdXN) to
+// the base block device name (sdX) via lsblk, falling back to symlink resolution
+// + partition-suffix stripping if lsblk fails.
+func baseDev(path string) string {
+	if out, err := exec.Command("lsblk", "-no", "pkname", path).Output(); err == nil {
+		if name := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0]); name != "" {
+			return name
+		}
+	}
+	// Resolve by-id/by-path symlinks to the real /dev/sdXN before stripping.
+	resolved := path
+	if r, err := filepath.EvalSymlinks(path); err == nil {
+		resolved = r
+	}
+	name := resolved
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		name = name[i+1:]
+	}
+	// sdb3 -> sdb ; nvme0n1p2 -> nvme0n1
+	name = strings.TrimRight(name, "0123456789")
+	name = strings.TrimSuffix(name, "p")
+	return name
+}
+
+func afterColon(s string) string {
+	if i := strings.Index(s, ":"); i >= 0 {
+		return strings.TrimSpace(s[i+1:])
+	}
+	return strings.TrimSpace(s)
+}
+
+func atoi(s string) int {
+	n, _ := strconv.Atoi(strings.TrimSpace(s))
+	return n
+}
+
+func firstInt(s string) int {
+	for _, f := range strings.Fields(s) {
+		if n, err := strconv.Atoi(strings.Trim(f, ":")); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+func lastInt(s string) int {
+	v := 0
+	for _, f := range strings.Fields(s) {
+		if n, err := strconv.Atoi(f); err == nil {
+			v = n
+		}
+	}
+	return v
+}

--- a/apps/baywatch/agent/hub.go
+++ b/apps/baywatch/agent/hub.go
@@ -1,0 +1,44 @@
+package main
+
+import "sync"
+
+// hub is a tiny fan-out for Server-Sent Events. The reconcile loop publishes
+// pre-framed SSE messages; each connected /v1/stream client gets its own
+// buffered channel. Slow clients drop messages rather than blocking the loop
+// (state is idempotent and re-synced on the next snapshot/poll).
+type hub struct {
+	mu   sync.Mutex
+	subs map[chan []byte]struct{}
+}
+
+func newHub() *hub {
+	return &hub{subs: make(map[chan []byte]struct{})}
+}
+
+func (h *hub) sub() chan []byte {
+	ch := make(chan []byte, 64)
+	h.mu.Lock()
+	h.subs[ch] = struct{}{}
+	h.mu.Unlock()
+	return ch
+}
+
+func (h *hub) unsub(ch chan []byte) {
+	h.mu.Lock()
+	if _, ok := h.subs[ch]; ok {
+		delete(h.subs, ch)
+		close(ch)
+	}
+	h.mu.Unlock()
+}
+
+func (h *hub) pub(msg []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for ch := range h.subs {
+		select {
+		case ch <- msg:
+		default: // drop for slow consumers
+		}
+	}
+}

--- a/apps/baywatch/agent/main.go
+++ b/apps/baywatch/agent/main.go
@@ -1,0 +1,536 @@
+// Command bw-agent is the BayWatch host agent. It runs as root via systemd on a
+// bare-metal Proxmox host, owns that host's SES enclosure LEDs, polls ZFS+SMART
+// health, and serves a small REST+SSE API for the BayWatch UI.
+//
+// It is the SINGLE writer of every caddy LED on the host (D2 in the plan): it
+// reconciles desired LED state (amber = unhealthy from ZFS/SMART, blue = a
+// time-boxed locate request) against the kernel SES sysfs every poll, writing
+// only on change. This supersedes the standalone drive-health-leds.sh timer.
+package main
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type config struct {
+	Bind          string
+	Token         string
+	HostLabel     string
+	Controller    string
+	Poll          time.Duration
+	SmartPoll     time.Duration
+	LocateDefault int
+	LocateMax     int
+}
+
+func loadConfig() config {
+	host, _ := os.Hostname()
+	c := config{
+		Bind:          envStr("BW_BIND", ":9099"),
+		Token:         envStr("BW_TOKEN", ""),
+		HostLabel:     envStr("BW_HOST_LABEL", host),
+		Controller:    envStr("BW_CONTROLLER", ""),
+		Poll:          time.Duration(envInt("BW_POLL", 3)) * time.Second,
+		SmartPoll:     time.Duration(envInt("BW_SMART_POLL", 60)) * time.Second,
+		LocateDefault: envInt("BW_LOCATE_DEFAULT", 120),
+		LocateMax:     envInt("BW_LOCATE_MAX", 600),
+	}
+	return c
+}
+
+type agent struct {
+	cfg    config
+	health *healthCache
+	hub    *hub
+
+	mu          sync.RWMutex
+	cur         *Snapshot            // latest published snapshot
+	locateUntil map[string]time.Time // compKey -> expiry
+
+	kick chan struct{} // request an immediate reconcile
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lmsgprefix)
+	log.SetPrefix("bw-agent: ")
+	cfg := loadConfig()
+	if cfg.Token == "" {
+		log.Println("WARNING: BW_TOKEN is empty - API auth is DISABLED (LAN-only). Set BW_TOKEN for production.")
+	}
+
+	a := &agent{
+		cfg:         cfg,
+		health:      newHealthCache(),
+		hub:         newHub(),
+		locateUntil: map[string]time.Time{},
+		kick:        make(chan struct{}, 1),
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go a.smartLoop(ctx)
+	go a.reconcileLoop(ctx)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /v1/healthz", a.handleHealthz)
+	mux.HandleFunc("GET /v1/enclosures", a.auth(a.handleEnclosures))
+	mux.HandleFunc("GET /v1/stream", a.auth(a.handleStream))
+	mux.HandleFunc("POST /v1/locate", a.auth(a.handleLocate))
+
+	srv := &http.Server{
+		Addr:              cfg.Bind,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		<-ctx.Done()
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutCtx)
+	}()
+
+	log.Printf("listening on %s as host=%q (poll=%s smart=%s)", cfg.Bind, cfg.HostLabel, cfg.Poll, cfg.SmartPoll)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("server: %v", err)
+	}
+}
+
+// --- reconcile -------------------------------------------------------------
+
+func (a *agent) reconcileLoop(ctx context.Context) {
+	// Reconcile immediately (no SMART yet) so the API serves within ~1s, then
+	// prime SMART asynchronously and reconcile again to fill in temps/identity.
+	// SMART across ~25 drives can take many seconds; never block first publish.
+	a.reconcile()
+	go func() {
+		if comps, err := readEnclosures(); err == nil {
+			a.health.refreshSmart(devsOf(comps))
+			select {
+			case a.kick <- struct{}{}:
+			default:
+			}
+		}
+	}()
+	t := time.NewTicker(a.cfg.Poll)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			a.reconcile()
+		case <-a.kick:
+			a.reconcile()
+		}
+	}
+}
+
+func (a *agent) smartLoop(ctx context.Context) {
+	t := time.NewTicker(a.cfg.SmartPoll)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if comps, err := readEnclosures(); err == nil {
+				a.health.refreshSmart(devsOf(comps))
+			}
+		}
+	}
+}
+
+// reconcile reads the hardware, computes desired LED state, writes only the
+// diffs, and publishes the resulting snapshot + per-slot change events.
+func (a *agent) reconcile() {
+	comps, err := readEnclosures()
+	if err != nil {
+		log.Printf("read enclosures: %v", err)
+		return
+	}
+	healthByDev := a.health.snapshot(devsOf(comps))
+	now := time.Now()
+
+	// Build enclosure grouping + friendly labels (rear vs numbered front boxes).
+	encOrder := []string{}        // enclosure names in stable order
+	encComps := map[string][]int{} // encName -> indexes into comps
+	encLID := map[string]string{}
+	for i, c := range comps {
+		if _, ok := encComps[c.encName]; !ok {
+			encOrder = append(encOrder, c.encName)
+			encLID[c.encName] = c.logicalID
+		}
+		encComps[c.encName] = append(encComps[c.encName], i)
+	}
+	sort.Strings(encOrder)
+	frontOrder := 0
+	encLabel := map[string]string{}
+	for _, name := range encOrder {
+		bays := len(encComps[name])
+		if bays > 2 {
+			frontOrder++
+			encLabel[name] = cageLabel(bays, frontOrder)
+		} else {
+			encLabel[name] = cageLabel(bays, 0)
+		}
+	}
+
+	var encs []Enclosure
+	var events []SlotEvent
+	prev := a.slotIndex() // previous published slots for diffing
+
+	for _, name := range encOrder {
+		idxs := encComps[name]
+		enc := Enclosure{
+			ID:        name,
+			LogicalID: encLID[name],
+			Label:     encLabel[name],
+			Bays:      len(idxs),
+		}
+		for _, i := range idxs {
+			c := &comps[i]
+			key := compKey(c.logicalID, c.slot)
+
+			present := c.dev != "" && !strings.EqualFold(c.status, "not installed")
+			dh := healthByDev[c.dev]
+			bad := false
+			reason := ""
+			if present {
+				bad, reason = dh.bad()
+			}
+
+			// Desired LED state, then write only on change (single writer).
+			desiredFault := bad
+			desiredLocate := a.locateActive(key, now)
+			if c.fault != desiredFault {
+				if e := setFault(c.compDir, desiredFault); e != nil {
+					log.Printf("setFault %s slot %d: %v", name, c.slot, e)
+				} else {
+					log.Printf("fault %s slot %d (%s) -> %v %s", name, c.slot, devOr(c.dev), desiredFault, reason)
+					c.fault = desiredFault
+				}
+			}
+			if c.locate != desiredLocate {
+				if e := setLocate(c.compDir, desiredLocate); e != nil {
+					log.Printf("setLocate %s slot %d: %v", name, c.slot, e)
+				} else {
+					c.locate = desiredLocate
+				}
+			}
+
+			state := StateHealthy
+			switch {
+			case !present:
+				state = StateEmpty
+			case desiredFault:
+				state = StateFault
+			}
+
+			slot := Slot{
+				Slot:        c.slot,
+				Comp:        c.comp,
+				EnclosureID: c.logicalID,
+				Present:     present,
+				State:       state,
+				Fault:       desiredFault,
+				Locate:      desiredLocate,
+				LocateUntil: a.locateExpiry(key, now),
+				Dev:         c.dev,
+				Model:       dh.Model,
+				Serial:      dh.Serial,
+				Size:        dh.Size,
+				TempC:       dh.TempC,
+				Smart:       smartLabel(present, dh),
+				Zfs:         zfsLabel(dh),
+				Pool:        dh.Pool,
+				Reason:      reason,
+			}
+			enc.Slots = append(enc.Slots, slot)
+
+			if changed(prev[key], slot) {
+				events = append(events, SlotEvent{Host: a.cfg.HostLabel, EnclosureID: c.logicalID, Slot: slot})
+			}
+		}
+		sort.Slice(enc.Slots, func(i, j int) bool { return enc.Slots[i].Slot < enc.Slots[j].Slot })
+		encs = append(encs, enc)
+	}
+
+	snap := &Snapshot{
+		Host:       a.cfg.HostLabel,
+		Controller: a.cfg.Controller,
+		TS:         now,
+		Enclosures: encs,
+	}
+	a.mu.Lock()
+	a.cur = snap
+	a.mu.Unlock()
+
+	for _, ev := range events {
+		a.hub.pub(sseFrame("slot", ev))
+	}
+}
+
+// --- locate state ----------------------------------------------------------
+
+func compKey(logicalID string, slot int) string { return logicalID + "#" + strconv.Itoa(slot) }
+
+func (a *agent) locateActive(key string, now time.Time) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	until, ok := a.locateUntil[key]
+	return ok && now.Before(until)
+}
+
+// locateExpiry returns the locate deadline as of the given reconcile time, so the
+// Slot's Locate and LocateUntil fields stay consistent within a single snapshot.
+func (a *agent) locateExpiry(key string, now time.Time) *time.Time {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	until, ok := a.locateUntil[key]
+	if !ok || now.After(until) {
+		return nil
+	}
+	u := until
+	return &u
+}
+
+func (a *agent) setLocateState(logicalID string, slot, seconds int) {
+	key := compKey(logicalID, slot)
+	a.mu.Lock()
+	if seconds <= 0 {
+		delete(a.locateUntil, key)
+	} else {
+		if seconds > a.cfg.LocateMax {
+			seconds = a.cfg.LocateMax
+		}
+		a.locateUntil[key] = time.Now().Add(time.Duration(seconds) * time.Second)
+	}
+	a.mu.Unlock()
+	select {
+	case a.kick <- struct{}{}:
+	default:
+	}
+}
+
+// slotIndex returns the last published slots keyed by compKey for diffing.
+func (a *agent) slotIndex() map[string]Slot {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	out := map[string]Slot{}
+	if a.cur == nil {
+		return out
+	}
+	for _, e := range a.cur.Enclosures {
+		for _, s := range e.Slots {
+			out[compKey(s.EnclosureID, s.Slot)] = s
+		}
+	}
+	return out
+}
+
+// --- HTTP handlers ---------------------------------------------------------
+
+func (a *agent) auth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if a.cfg.Token != "" {
+			got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+			if subtle.ConstantTimeCompare([]byte(got), []byte(a.cfg.Token)) != 1 {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+		// No CORS header: only bw-ui talks to the agent (server-side, same LAN);
+		// browsers never call the agent directly.
+		next(w, r)
+	}
+}
+
+func (a *agent) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"ok":true}`))
+}
+
+func (a *agent) handleEnclosures(w http.ResponseWriter, _ *http.Request) {
+	a.mu.RLock()
+	snap := a.cur
+	a.mu.RUnlock()
+	if snap == nil {
+		http.Error(w, "warming up", http.StatusServiceUnavailable)
+		return
+	}
+	writeJSON(w, snap)
+}
+
+func (a *agent) handleStream(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	ch := a.hub.sub()
+	defer a.hub.unsub(ch)
+
+	// Send the current full snapshot first so a fresh client renders immediately.
+	a.mu.RLock()
+	snap := a.cur
+	a.mu.RUnlock()
+	if snap != nil {
+		_, _ = w.Write(sseFrame("snapshot", snap))
+		flusher.Flush()
+	}
+
+	ka := time.NewTicker(20 * time.Second)
+	defer ka.Stop()
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-ch:
+			if _, err := w.Write(msg); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-ka.C:
+			if _, err := w.Write([]byte(": keepalive\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func (a *agent) handleLocate(w http.ResponseWriter, r *http.Request) {
+	var req LocateRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 16<<10)).Decode(&req); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	if req.EnclosureID == "" {
+		http.Error(w, "enclosure_id required", http.StatusBadRequest)
+		return
+	}
+	if !a.slotExists(req.EnclosureID, req.Slot) {
+		http.Error(w, "no such slot", http.StatusNotFound)
+		return
+	}
+	a.setLocateState(req.EnclosureID, req.Slot, req.Seconds)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = fmt.Fprintf(w, `{"ok":true,"enclosure_id":%q,"slot":%d,"seconds":%d}`, req.EnclosureID, req.Slot, req.Seconds)
+}
+
+func (a *agent) slotExists(logicalID string, slot int) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.cur == nil {
+		return false
+	}
+	for _, e := range a.cur.Enclosures {
+		if e.LogicalID != logicalID {
+			continue
+		}
+		for _, s := range e.Slots {
+			if s.Slot == slot {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func devsOf(comps []rawComp) []string {
+	out := make([]string, 0, len(comps))
+	for _, c := range comps {
+		if c.dev != "" {
+			out = append(out, c.dev)
+		}
+	}
+	return out
+}
+
+func changed(prev, cur Slot) bool {
+	return prev.State != cur.State ||
+		prev.Fault != cur.Fault ||
+		prev.Locate != cur.Locate ||
+		prev.Dev != cur.Dev ||
+		prev.TempC != cur.TempC ||
+		prev.Zfs != cur.Zfs ||
+		prev.Smart != cur.Smart ||
+		prev.Reason != cur.Reason ||
+		(prev.LocateUntil == nil) != (cur.LocateUntil == nil)
+}
+
+func smartLabel(present bool, dh driveHealth) string {
+	if !present {
+		return "-"
+	}
+	if dh.SmartStr == "" {
+		return "-"
+	}
+	return dh.SmartStr
+}
+
+func zfsLabel(dh driveHealth) string {
+	if dh.Zfs == "" {
+		return "-"
+	}
+	return dh.Zfs
+}
+
+func devOr(dev string) string {
+	if dev == "" {
+		return "empty"
+	}
+	return dev
+}
+
+func sseFrame(event string, v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return []byte("event: error\ndata: {}\n\n")
+	}
+	return []byte("event: " + event + "\ndata: " + string(b) + "\n\n")
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func envStr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(k string, def int) int {
+	if v := os.Getenv(k); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}

--- a/apps/baywatch/agent/ses.go
+++ b/apps/baywatch/agent/ses.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// enclosureRoot is the kernel SCSI Enclosure Services sysfs interface. Each
+// enclosure exposes per-bay component dirs with fault/locate/status/slot files
+// and a `device/block/<sdX>` symlink to the installed drive. We proved live on
+// the HPE Gen9 H240/P440ar backplanes that writing these files physically drives
+// the caddy LEDs even in HBA mode (where ssacli refuses).
+const enclosureRoot = "/sys/class/enclosure"
+
+// rawComp is a discovered SES element (one physical bay) plus its live sysfs state.
+type rawComp struct {
+	encName   string // sysfs enclosure dir, e.g. 2:0:8:0
+	logicalID string // enclosure logical_id, e.g. 0x50014380435ccf80
+	compDir   string // absolute path to the component dir
+	comp      string // basename, e.g. ArrayElement0006
+	slot      int    // SES slot number
+	status    string // OK | not installed | ...
+	fault     bool   // current fault sysfs bit
+	locate    bool   // current locate sysfs bit
+	dev       string // installed block device basename, e.g. sdk ("" if empty)
+}
+
+// readEnclosures walks the SES sysfs tree and returns every bay across every
+// controller on this host. Reads are cheap (pure sysfs), so the reconcile loop
+// can call this every cycle.
+func readEnclosures() ([]rawComp, error) {
+	encDirs, err := os.ReadDir(enclosureRoot)
+	if err != nil {
+		return nil, err
+	}
+	var out []rawComp
+	for _, e := range encDirs {
+		encName := e.Name()
+		encPath := filepath.Join(enclosureRoot, encName)
+		logicalID := strings.TrimSpace(readFile(filepath.Join(encPath, "id")))
+
+		comps, err := os.ReadDir(encPath)
+		if err != nil {
+			continue
+		}
+		for _, c := range comps {
+			compDir := filepath.Join(encPath, c.Name())
+			slotStr := readFile(filepath.Join(compDir, "slot"))
+			if slotStr == "" {
+				continue // not a bay component (e.g. enclosure/power/temp elements)
+			}
+			slot, err := strconv.Atoi(strings.TrimSpace(slotStr))
+			if err != nil {
+				continue
+			}
+			rc := rawComp{
+				encName:   encName,
+				logicalID: logicalID,
+				compDir:   compDir,
+				comp:      c.Name(),
+				slot:      slot,
+				status:    strings.TrimSpace(readFile(filepath.Join(compDir, "status"))),
+				fault:     sysfsBitOn(readFile(filepath.Join(compDir, "fault"))),
+				locate:    sysfsBitOn(readFile(filepath.Join(compDir, "locate"))),
+			}
+			// device/block/<sdX> -> installed drive
+			blockDir := filepath.Join(compDir, "device", "block")
+			if entries, err := os.ReadDir(blockDir); err == nil && len(entries) > 0 {
+				rc.dev = entries[0].Name()
+			}
+			out = append(out, rc)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].encName != out[j].encName {
+			return out[i].encName < out[j].encName
+		}
+		return out[i].slot < out[j].slot
+	})
+	return out, nil
+}
+
+// setFault commands the amber fault LED. We only ever write on a real change
+// (the caller diffs), so this never spams the backplane.
+func setFault(compDir string, on bool) error {
+	return writeBit(filepath.Join(compDir, "fault"), on)
+}
+
+// setLocate commands the blue locate/identify LED.
+func setLocate(compDir string, on bool) error {
+	return writeBit(filepath.Join(compDir, "locate"), on)
+}
+
+func writeBit(path string, on bool) error {
+	v := "0"
+	if on {
+		v = "1"
+	}
+	return os.WriteFile(path, []byte(v), 0)
+}
+
+// sysfsBitOn normalizes the enclosure LED files. The kernel enclosure driver
+// reads a "fault" of 1 back as 6 (it ORs in the FAULT_SENSED/REQSTD bits), and
+// trailing newlines are common - so treat any nonzero as on.
+func sysfsBitOn(s string) bool {
+	s = strings.TrimSpace(s)
+	return s != "" && s != "0"
+}
+
+func readFile(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// cageLabel derives a friendly label for a cage. The HPE silkscreen box number
+// is not exposed over SES, so we label rear 2-bay cages explicitly and number
+// the front 8-bay cages 1..N in stable logical_id order. order is the cage index
+// among same-size cages.
+func cageLabel(bays, order int) string {
+	switch {
+	case bays <= 2:
+		return "Rear cage"
+	default:
+		return "Front box " + strconv.Itoa(order)
+	}
+}

--- a/apps/baywatch/agent/types.go
+++ b/apps/baywatch/agent/types.go
@@ -1,0 +1,71 @@
+package main
+
+import "time"
+
+// Wire contract (BayWatch v1). The agent serves these; bw-ui consumes them.
+// JSON is the contract between agent and UI - keep field names stable.
+
+// SlotState is the rendered LED/health state of a bay.
+const (
+	StateHealthy = "healthy" // drive present, ZFS ONLINE + SMART ok -> green (fault off)
+	StateFault   = "fault"   // drive present but ZFS not-ONLINE/errors or SMART failing -> amber
+	StateEmpty   = "empty"   // no drive in this bay (SES element exists, still locatable)
+	StateUnknown = "unknown" // present but health not yet evaluated
+)
+
+// Slot is one physical bay, anchored on (EnclosureID logical_id, Slot number).
+// The anchor is stable even when the drive is pulled/dead - that is the whole
+// point of the locator (D1 in the plan).
+type Slot struct {
+	Slot        int        `json:"slot"`         // SES slot number (silkscreen bay)
+	Comp        string     `json:"comp"`         // sysfs component dir, e.g. ArrayElement0006
+	EnclosureID string     `json:"enclosure_id"` // enclosure logical_id, e.g. 0x50014380435ccf80
+	Present     bool       `json:"present"`      // a drive is installed
+	State       string     `json:"state"`        // one of the State* constants
+	Fault       bool       `json:"fault"`        // amber fault LED commanded on
+	Locate      bool       `json:"locate"`       // blue locate LED commanded on
+	LocateUntil *time.Time `json:"locate_until"` // when the locate auto-clears (nil if off)
+	Dev         string     `json:"dev"`          // current block device, e.g. sdk ("" if empty)
+	Model       string     `json:"model"`        // drive model
+	Serial      string     `json:"serial"`       // drive serial (correlation anchor for health)
+	Size        string     `json:"size"`         // human size, e.g. 1.6T
+	TempC       int        `json:"temp_c"`       // drive temperature in C (0 if unknown)
+	Smart       string     `json:"smart"`        // PASSED|FAILED|OK|- (overall SMART health)
+	Zfs         string     `json:"zfs"`          // ONLINE|DEGRADED|FAULTED|... or - (not in a pool)
+	Pool        string     `json:"pool"`         // ZFS pool name ("" if not a pool member)
+	Reason      string     `json:"reason"`       // why fault (empty when healthy)
+}
+
+// Enclosure is one drive cage (an SES enclosure).
+type Enclosure struct {
+	ID        string `json:"id"`         // sysfs enclosure name, e.g. 2:0:8:0
+	LogicalID string `json:"logical_id"` // stable SES logical_id, e.g. 0x50014380435ccf80
+	Label     string `json:"label"`      // friendly cage label
+	Bays      int    `json:"bays"`       // number of slots in this cage
+	Slots     []Slot `json:"slots"`      // ordered by slot number
+}
+
+// Snapshot is the full agent view returned by GET /v1/enclosures and pushed as
+// the first SSE event.
+type Snapshot struct {
+	Host       string      `json:"host"`       // host label, e.g. DL380G9
+	Controller string      `json:"controller"` // controller summary, e.g. "Smart HBA H240 x3 + H240ar"
+	TS         time.Time   `json:"ts"`         // when this snapshot was produced
+	Enclosures []Enclosure `json:"enclosures"`
+}
+
+// SlotEvent is one incremental SSE change pushed on GET /v1/stream after the
+// initial snapshot. The UI applies it by (Host, EnclosureID, Slot.Slot).
+type SlotEvent struct {
+	Host        string `json:"host"`
+	EnclosureID string `json:"enclosure_id"`
+	Slot        Slot   `json:"slot"`
+}
+
+// LocateRequest is the body of POST /v1/locate. Seconds is clamped to LocateMax;
+// 0 means "clear the locate now".
+type LocateRequest struct {
+	EnclosureID string `json:"enclosure_id"` // logical_id of the cage
+	Slot        int    `json:"slot"`         // slot number in that cage
+	Seconds     int    `json:"seconds"`      // duration; 0 = clear
+}

--- a/apps/baywatch/deploy/baywatch-agent.service
+++ b/apps/baywatch/deploy/baywatch-agent.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=BayWatch host agent (SES drive-bay health + locate LEDs)
+Documentation=https://baywatch.iacob.uk
+After=network-online.target zfs.target
+Wants=network-online.target
+# Stop hammering restarts if the host is fundamentally broken (e.g. /sys missing).
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User=root
+EnvironmentFile=/etc/baywatch/agent.env
+ExecStart=/usr/local/sbin/bw-agent
+Restart=on-failure
+RestartSec=5
+# Root is required to write the SES LED sysfs files and run smartctl/zpool.
+# Keep sandboxing light so /sys (enclosure LEDs) and /dev (smartctl) stay reachable.
+NoNewPrivileges=yes
+ProtectHome=yes
+# Bound resource use so a token holder can't exhaust fds via SSE stream spam.
+LimitNOFILE=4096
+LimitNPROC=512
+
+[Install]
+WantedBy=multi-user.target

--- a/apps/baywatch/deploy/install-agent.sh
+++ b/apps/baywatch/deploy/install-agent.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# install-agent.sh - install/upgrade the BayWatch host agent on a Proxmox host.
+# Run ON the host (root). Expects these files staged in /tmp:
+#   /tmp/bw-agent                  the linux/amd64 static binary
+#   /tmp/baywatch-agent.service    the systemd unit
+# And these env vars set by the caller:
+#   BW_TOKEN        shared bearer token (same on every host + the K8s UI secret)
+#   BW_CONTROLLER   human controller summary, e.g. "Smart HBA H240 x3 + H240ar"
+#   BW_HOST_LABEL   optional; defaults to hostname
+set -euo pipefail
+
+: "${BW_TOKEN:?BW_TOKEN must be set}"
+: "${BW_CONTROLLER:=}"
+: "${BW_HOST_LABEL:=$(hostname)}"
+
+echo "[*] Retiring the standalone drive-health-leds timer (folded into bw-agent)"
+systemctl disable --now drive-health-leds.timer 2>/dev/null || true
+systemctl stop drive-health-leds.service 2>/dev/null || true
+
+echo "[*] Installing binary -> /usr/local/sbin/bw-agent"
+install -m 0755 /tmp/bw-agent /usr/local/sbin/bw-agent
+
+echo "[*] Writing /etc/baywatch/agent.env (0600)"
+install -d -m 0755 /etc/baywatch
+umask 077
+cat > /etc/baywatch/agent.env <<ENV
+BW_BIND=:9099
+BW_TOKEN=${BW_TOKEN}
+BW_HOST_LABEL=${BW_HOST_LABEL}
+BW_CONTROLLER=${BW_CONTROLLER}
+BW_POLL=3
+BW_SMART_POLL=60
+BW_LOCATE_DEFAULT=120
+BW_LOCATE_MAX=600
+ENV
+chmod 0600 /etc/baywatch/agent.env
+
+echo "[*] Installing systemd unit"
+install -m 0644 /tmp/baywatch-agent.service /etc/systemd/system/baywatch-agent.service
+systemctl daemon-reload
+systemctl enable --now baywatch-agent.service
+
+sleep 2
+echo "[*] Verifying..."
+if ! systemctl is-active --quiet baywatch-agent.service; then
+  echo "ERROR: baywatch-agent.service is not active" >&2
+  systemctl --no-pager status baywatch-agent.service || true
+  exit 1
+fi
+if ! curl -fsS --max-time 5 http://127.0.0.1:9099/v1/healthz >/dev/null; then
+  echo "ERROR: agent healthz did not respond" >&2
+  exit 1
+fi
+echo "[*] OK - baywatch-agent active and healthy on $(hostname)"

--- a/apps/baywatch/ui/Dockerfile
+++ b/apps/baywatch/ui/Dockerfile
@@ -1,0 +1,13 @@
+# Repo-standard reproducible build for the BayWatch UI.
+# (The live image was pushed with `ko`; this Dockerfile is the docker-equivalent.)
+FROM golang:1.24-alpine AS build
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -trimpath -ldflags="-s -w" -o /bw-ui .
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=build /bw-ui /bw-ui
+EXPOSE 8080
+USER 65532:65532
+ENTRYPOINT ["/bw-ui"]

--- a/apps/baywatch/ui/fleet.go
+++ b/apps/baywatch/ui/fleet.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// agentConn is one configured bw-agent endpoint.
+type agentConn struct {
+	label string // configured display label (fallback before first snapshot)
+	url   string // base URL, e.g. http://192.168.1.150:9099
+}
+
+// fleet holds the merged, live view of every host and streams changes to the
+// browser hub. Each agent gets a goroutine that keeps an SSE connection open,
+// applies snapshot+slot events into the model, and republishes to browsers.
+type fleet struct {
+	token  string
+	hub    *hub
+	client *http.Client
+
+	mu        sync.RWMutex
+	hosts     map[string]*HostState // keyed by reported host name
+	hostURL   map[string]string     // reported host -> agent base URL (for locate)
+	labelHost map[string]string     // configured label -> reported host
+}
+
+func newFleet(token string, h *hub) *fleet {
+	return &fleet{
+		token:     token,
+		hub:       h,
+		client:    &http.Client{Timeout: 0}, // SSE is long-lived; per-request timeouts set below
+		hosts:     map[string]*HostState{},
+		hostURL:   map[string]string{},
+		labelHost: map[string]string{},
+	}
+}
+
+func (f *fleet) run(ctx context.Context, agents []agentConn) {
+	for _, a := range agents {
+		go f.connectLoop(ctx, a)
+	}
+}
+
+// connectLoop keeps one agent's SSE stream connected, reconnecting with backoff.
+func (f *fleet) connectLoop(ctx context.Context, a agentConn) {
+	backoff := time.Second
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		err := f.stream(ctx, a)
+		if ctx.Err() != nil {
+			return
+		}
+		f.markOffline(a)
+		if err != nil {
+			log.Printf("agent %s (%s) disconnected: %v", a.label, a.url, err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < 15*time.Second {
+			backoff *= 2
+		}
+	}
+}
+
+func (f *fleet) stream(ctx context.Context, a agentConn) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.url+"/v1/stream", nil)
+	if err != nil {
+		return err
+	}
+	if f.token != "" {
+		req.Header.Set("Authorization", "Bearer "+f.token)
+	}
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return &httpError{resp.StatusCode}
+	}
+
+	sc := bufio.NewScanner(resp.Body)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	var event, data string
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case line == "":
+			if data != "" {
+				f.dispatch(a, event, data)
+			}
+			event, data = "", ""
+		case strings.HasPrefix(line, ":"):
+			// comment / keepalive
+		case strings.HasPrefix(line, "event:"):
+			event = strings.TrimSpace(line[len("event:"):])
+		case strings.HasPrefix(line, "data:"):
+			if data != "" {
+				data += "\n" // SSE spec: multiple data: lines join with newline
+			}
+			data += strings.TrimSpace(line[len("data:"):])
+		}
+	}
+	return sc.Err()
+}
+
+func (f *fleet) dispatch(a agentConn, event, data string) {
+	switch event {
+	case "snapshot":
+		var snap Snapshot
+		if err := json.Unmarshal([]byte(data), &snap); err != nil {
+			log.Printf("bad snapshot from %s: %v", a.label, err)
+			return
+		}
+		f.applySnapshot(a, snap)
+	case "slot":
+		var ev SlotEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			return
+		}
+		f.applySlot(ev)
+	}
+}
+
+func (f *fleet) applySnapshot(a agentConn, snap Snapshot) {
+	hs := &HostState{
+		Host:       snap.Host,
+		Controller: snap.Controller,
+		Online:     true,
+		LastSeen:   time.Now(),
+		Enclosures: snap.Enclosures,
+	}
+	hs.recount()
+	f.mu.Lock()
+	f.hosts[snap.Host] = hs
+	f.hostURL[snap.Host] = a.url
+	f.labelHost[a.label] = snap.Host
+	f.mu.Unlock()
+	f.hub.pub(sseFrame("host", HostEvent{Host: *hs}))
+}
+
+func (f *fleet) applySlot(ev SlotEvent) {
+	f.mu.Lock()
+	hs := f.hosts[ev.Host]
+	if hs == nil {
+		f.mu.Unlock()
+		return
+	}
+	hs.LastSeen = time.Now()
+	hs.Online = true
+	for ei := range hs.Enclosures {
+		if hs.Enclosures[ei].LogicalID != ev.EnclosureID {
+			continue
+		}
+		for si := range hs.Enclosures[ei].Slots {
+			if hs.Enclosures[ei].Slots[si].Slot == ev.Slot.Slot {
+				hs.Enclosures[ei].Slots[si] = ev.Slot
+			}
+		}
+	}
+	hs.recount()
+	f.mu.Unlock()
+	f.hub.pub(sseFrame("slot", ev))
+}
+
+func (f *fleet) markOffline(a agentConn) {
+	f.mu.Lock()
+	host := f.labelHost[a.label]
+	hs := f.hosts[host]
+	if hs != nil {
+		hs.Online = false
+	}
+	var snapshot *HostState
+	if hs != nil {
+		c := *hs
+		snapshot = &c
+	}
+	f.mu.Unlock()
+	if snapshot != nil {
+		f.hub.pub(sseFrame("host", HostEvent{Host: *snapshot}))
+	}
+}
+
+// snapshot returns a deep-ish copy of the merged fleet for GET /api/fleet.
+func (f *fleet) snapshot() Fleet {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	out := Fleet{TS: time.Now()}
+	for _, hs := range f.hosts {
+		out.Hosts = append(out.Hosts, *hs)
+	}
+	// stable order by host name
+	for i := 0; i < len(out.Hosts); i++ {
+		for j := i + 1; j < len(out.Hosts); j++ {
+			if out.Hosts[j].Host < out.Hosts[i].Host {
+				out.Hosts[i], out.Hosts[j] = out.Hosts[j], out.Hosts[i]
+			}
+		}
+	}
+	return out
+}
+
+// urlForHost returns the agent base URL serving a given reported host.
+func (f *fleet) urlForHost(host string) (string, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	u, ok := f.hostURL[host]
+	return u, ok
+}
+
+func (hs *HostState) recount() {
+	hs.Drives, hs.Faults, hs.Locates, hs.Empty = 0, 0, 0, 0
+	for _, e := range hs.Enclosures {
+		for _, s := range e.Slots {
+			if s.Present {
+				hs.Drives++
+			} else {
+				hs.Empty++
+			}
+			if s.Fault {
+				hs.Faults++
+			}
+			if s.Locate {
+				hs.Locates++
+			}
+		}
+	}
+}
+
+type httpError struct{ code int }
+
+func (e *httpError) Error() string { return "agent returned HTTP " + http.StatusText(e.code) }

--- a/apps/baywatch/ui/go.mod
+++ b/apps/baywatch/ui/go.mod
@@ -1,0 +1,3 @@
+module github.com/andrei-iacobb/baywatch/ui
+
+go 1.24

--- a/apps/baywatch/ui/hub.go
+++ b/apps/baywatch/ui/hub.go
@@ -1,0 +1,40 @@
+package main
+
+import "sync"
+
+// hub fans pre-framed SSE messages out to every connected browser. Slow clients
+// drop messages rather than blocking (the next /api/fleet or event re-syncs).
+type hub struct {
+	mu   sync.Mutex
+	subs map[chan []byte]struct{}
+}
+
+func newHub() *hub { return &hub{subs: make(map[chan []byte]struct{})} }
+
+func (h *hub) sub() chan []byte {
+	ch := make(chan []byte, 128)
+	h.mu.Lock()
+	h.subs[ch] = struct{}{}
+	h.mu.Unlock()
+	return ch
+}
+
+func (h *hub) unsub(ch chan []byte) {
+	h.mu.Lock()
+	if _, ok := h.subs[ch]; ok {
+		delete(h.subs, ch)
+		close(ch)
+	}
+	h.mu.Unlock()
+}
+
+func (h *hub) pub(msg []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for ch := range h.subs {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+}

--- a/apps/baywatch/ui/main.go
+++ b/apps/baywatch/ui/main.go
@@ -1,0 +1,225 @@
+// Command bw-ui is the BayWatch aggregator. It runs in Kubernetes, keeps a live
+// SSE connection to each bw-agent on the LAN, merges them into one fleet view,
+// serves an embedded SVG-chassis frontend, fans agent changes out to browsers
+// over SSE, and proxies time-boxed locate requests to the owning agent.
+//
+// It touches no hardware. If it dies, the agents keep driving health LEDs.
+package main
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+//go:embed static
+var staticFS embed.FS
+
+type config struct {
+	Bind          string
+	Token         string
+	Agents        []agentConn
+	LocateDefault int
+}
+
+func loadConfig() config {
+	c := config{
+		Bind:          envStr("BW_BIND", ":8080"),
+		Token:         envStr("BW_TOKEN", ""),
+		Agents:        parseAgents(envStr("BW_AGENTS", "")),
+		LocateDefault: envInt("BW_LOCATE_DEFAULT", 120),
+	}
+	return c
+}
+
+// parseAgents reads "label=url,label=url" into agentConn entries.
+func parseAgents(s string) []agentConn {
+	var out []agentConn
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		label, url, ok := strings.Cut(part, "=")
+		if !ok {
+			log.Printf("ignoring malformed BW_AGENTS entry %q (want label=url)", part)
+			continue
+		}
+		out = append(out, agentConn{label: strings.TrimSpace(label), url: strings.TrimRight(strings.TrimSpace(url), "/")})
+	}
+	return out
+}
+
+type server struct {
+	cfg   config
+	fleet *fleet
+	hub   *hub
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lmsgprefix)
+	log.SetPrefix("bw-ui: ")
+	cfg := loadConfig()
+	if len(cfg.Agents) == 0 {
+		log.Println("WARNING: BW_AGENTS is empty - no host agents configured")
+	}
+	if cfg.Token == "" {
+		log.Println("WARNING: BW_TOKEN empty - calling agents without auth")
+	}
+
+	h := newHub()
+	s := &server{cfg: cfg, fleet: newFleet(cfg.Token, h), hub: h}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	s.fleet.run(ctx, cfg.Agents)
+
+	sub, _ := fs.Sub(staticFS, "static")
+	mux := http.NewServeMux()
+	mux.Handle("GET /", http.FileServer(http.FS(sub)))
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{"ok":true}`)) })
+	mux.HandleFunc("GET /api/config", s.handleConfig)
+	mux.HandleFunc("GET /api/fleet", s.handleFleet)
+	mux.HandleFunc("GET /api/stream", s.handleStream)
+	mux.HandleFunc("POST /api/locate", s.handleLocate)
+
+	srv := &http.Server{Addr: cfg.Bind, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		<-ctx.Done()
+		sc, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(sc)
+	}()
+
+	log.Printf("listening on %s, %d agent(s)", cfg.Bind, len(cfg.Agents))
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("server: %v", err)
+	}
+}
+
+func (s *server) handleConfig(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, map[string]any{"locate_default": s.cfg.LocateDefault})
+}
+
+func (s *server) handleFleet(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, s.fleet.snapshot())
+}
+
+func (s *server) handleStream(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	ch := s.hub.sub()
+	defer s.hub.unsub(ch)
+
+	// Initial full fleet so a fresh browser renders immediately.
+	_, _ = w.Write(sseFrame("fleet", s.fleet.snapshot()))
+	flusher.Flush()
+
+	ka := time.NewTicker(20 * time.Second)
+	defer ka.Stop()
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-ch:
+			if _, err := w.Write(msg); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-ka.C:
+			if _, err := w.Write([]byte(": keepalive\n\n")); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func (s *server) handleLocate(w http.ResponseWriter, r *http.Request) {
+	var req LocateRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err != nil {
+		http.Error(w, "bad json", http.StatusBadRequest)
+		return
+	}
+	if req.Host == "" || req.EnclosureID == "" {
+		http.Error(w, "host and enclosure_id required", http.StatusBadRequest)
+		return
+	}
+	url, ok := s.fleet.urlForHost(req.Host)
+	if !ok {
+		http.Error(w, "unknown or offline host", http.StatusNotFound)
+		return
+	}
+	body, _ := json.Marshal(map[string]any{
+		"enclosure_id": req.EnclosureID,
+		"slot":         req.Slot,
+		"seconds":      req.Seconds,
+	})
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	areq, _ := http.NewRequestWithContext(ctx, http.MethodPost, url+"/v1/locate", bytes.NewReader(body))
+	areq.Header.Set("Content-Type", "application/json")
+	if s.cfg.Token != "" {
+		areq.Header.Set("Authorization", "Bearer "+s.cfg.Token)
+	}
+	resp, err := http.DefaultClient.Do(areq)
+	if err != nil {
+		http.Error(w, "agent unreachable", http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, io.LimitReader(resp.Body, 1<<16))
+}
+
+// --- helpers ---
+
+func sseFrame(event string, v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return []byte("event: error\ndata: {}\n\n")
+	}
+	return []byte("event: " + event + "\ndata: " + string(b) + "\n\n")
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func envStr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(k string, def int) int {
+	if v := os.Getenv(k); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}

--- a/apps/baywatch/ui/static/index.html
+++ b/apps/baywatch/ui/static/index.html
@@ -1,0 +1,414 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BayWatch - drive bay health</title>
+<style>
+  :root{
+    --bg:#0c0e14; --panel:rgba(22,26,35,.72); --panel2:#1c212d; --ink:#e8ebf2;
+    --t2:#aab2c2; --t3:#7c869a; --t4:#586074; --line:#252b3a; --line2:#323a4d;
+    --green:#34d399; --amber:#f59e0b; --blue:#3b82f6; --grey:#4b5563; --red:#ef4444;
+    --acc:#7c9cff;
+    --radius:13px;
+  }
+  *{box-sizing:border-box}
+  html{color-scheme:dark}
+  body{margin:0;background:
+      radial-gradient(1100px 600px at 80% -10%, #15203a55, transparent),
+      radial-gradient(900px 500px at -10% 10%, #1a162e44, transparent),
+      var(--bg);
+    color:var(--ink);min-height:100vh;
+    font:14px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    -webkit-font-smoothing:antialiased;}
+  .mono{font-family:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;font-variant-numeric:tabular-nums}
+  main{max-width:1180px;margin:0 auto;padding:26px 22px 80px}
+
+  /* header */
+  header.top{display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin-bottom:22px}
+  .brand{display:flex;align-items:center;gap:11px}
+  .logo{width:30px;height:30px;border-radius:8px;background:linear-gradient(150deg,#3b82f6,#7c9cff);
+    display:grid;place-items:center;box-shadow:0 0 22px #3b82f655}
+  .logo i{width:11px;height:11px;border-radius:50%;background:#0c0e14;box-shadow:0 0 0 3px #ffffff22 inset}
+  h1{font-size:18px;font-weight:650;margin:0;letter-spacing:-.01em}
+  .sub{color:var(--t3);font-size:12px;margin-top:1px}
+  .spacer{flex:1}
+  .conn{display:inline-flex;align-items:center;gap:7px;font-size:12px;color:var(--t2);
+    border:1px solid var(--line);border-radius:999px;padding:5px 11px;background:var(--panel2)}
+  .conn .dot{width:8px;height:8px;border-radius:50%;background:var(--grey)}
+  .conn.live .dot{background:var(--green);box-shadow:0 0 9px var(--green);animation:breathe 2.4s ease-in-out infinite}
+  .conn.down .dot{background:var(--red);box-shadow:0 0 9px var(--red)}
+  @keyframes breathe{50%{opacity:.45}}
+
+  /* fleet summary chips */
+  .fleetbar{display:flex;gap:9px;flex-wrap:wrap;margin-bottom:20px}
+  .chip{display:flex;align-items:baseline;gap:7px;border:1px solid var(--line);border-radius:10px;
+    padding:8px 13px;background:var(--panel2)}
+  .chip b{font-size:16px;font-weight:650}
+  .chip span{font-size:11px;color:var(--t3);text-transform:uppercase;letter-spacing:.05em}
+  .chip.warn b{color:var(--amber)} .chip.loc b{color:var(--blue)}
+
+  /* host card */
+  .host{border:1px solid var(--line);border-radius:var(--radius);background:var(--panel);
+    backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);margin-bottom:18px;overflow:hidden}
+  .host > .hd{display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:14px 18px;border-bottom:1px solid var(--line)}
+  .host .name{font-size:15px;font-weight:600;letter-spacing:-.01em}
+  .host .ctrl{font-size:12px;color:var(--t3)}
+  .badge{font-size:11px;font-weight:600;padding:3px 9px;border-radius:999px;border:1px solid var(--line2)}
+  .badge.up{color:var(--green);border-color:#1f5d47;background:#0f2a20}
+  .badge.down{color:var(--red);border-color:#5d2424;background:#2a1212}
+  .mini{font-size:11.5px;color:var(--t3)}
+  .mini b{color:var(--t2);font-weight:600}
+  .body{padding:6px 18px 18px}
+
+  /* cage */
+  .cage{margin-top:14px}
+  .cage .lbl{display:flex;align-items:center;gap:8px;font-size:11px;color:var(--t3);
+    text-transform:uppercase;letter-spacing:.06em;margin:0 2px 8px}
+  .cage .lbl .lid{color:var(--t4);font-size:10.5px}
+  .bays{display:flex;gap:8px;flex-wrap:wrap}
+
+  /* a bay = a drive caddy */
+  .bay{position:relative;width:54px;height:64px;border:1px solid var(--line2);border-radius:7px;
+    background:linear-gradient(180deg,#10141d,#0b0e15);cursor:pointer;padding:6px 6px 5px;
+    display:flex;flex-direction:column;justify-content:space-between;text-align:left;
+    color:var(--t2);font:inherit;transition:transform .12s ease,border-color .12s ease,box-shadow .12s ease}
+  .bay:hover{transform:translateY(-2px);border-color:#3c465c;box-shadow:0 6px 18px #0008}
+  .bay:focus-visible{outline:2px solid var(--acc);outline-offset:2px}
+  .bay .slotno{font-size:10px;color:var(--t4);line-height:1}
+  .bay .dev{font-size:10px;color:var(--t3);line-height:1.1;font-family:ui-monospace,Menlo,monospace}
+  .bay .led{width:12px;height:12px;border-radius:50%;background:var(--grey);align-self:flex-start}
+  .bay .cap{font-size:9.5px;color:var(--t4);font-family:ui-monospace,Menlo,monospace;
+    font-variant-numeric:tabular-nums;line-height:1}
+
+  .bay.healthy .led{background:var(--green);box-shadow:0 0 8px var(--green)}
+  .bay.healthy{border-color:#1e4736}
+  .bay.fault .led{background:var(--amber);box-shadow:0 0 10px var(--amber)}
+  .bay.fault{border-color:#7a5512;background:linear-gradient(180deg,#1d160a,#0b0e15)}
+  .bay.empty{opacity:.6;background:repeating-linear-gradient(135deg,#0c0f17,#0c0f17 6px,#0e121b 6px,#0e121b 12px)}
+  .bay.empty .led{background:#333a49;box-shadow:none}
+  .bay.locate{border-color:var(--blue)}
+  .bay.locate .led{background:var(--blue);box-shadow:0 0 12px var(--blue);animation:pulse 1.1s ease-in-out infinite}
+  .bay.locate::after{content:"";position:absolute;inset:-1px;border-radius:7px;border:1px solid var(--blue);
+    animation:pulse 1.1s ease-in-out infinite;pointer-events:none}
+  .bay .ring{display:none}
+  @keyframes pulse{0%,100%{opacity:1}50%{opacity:.3}}
+
+  .bay.pending{opacity:.55;pointer-events:none}
+
+  /* tooltip */
+  #tip{position:fixed;z-index:50;max-width:280px;pointer-events:none;opacity:0;transform:translateY(4px);
+    transition:opacity .1s ease,transform .1s ease;
+    background:#0b0e15;border:1px solid var(--line2);border-radius:10px;padding:11px 13px;
+    box-shadow:0 12px 40px #000a;font-size:12px}
+  #tip.show{opacity:1;transform:translateY(0)}
+  #tip .th{display:flex;align-items:center;gap:8px;margin-bottom:7px}
+  #tip .th .led{width:9px;height:9px;border-radius:50%}
+  #tip .th b{font-size:12.5px}
+  #tip table{border-collapse:collapse;width:100%}
+  #tip td{padding:1.5px 0;vertical-align:top}
+  #tip td.k{color:var(--t3);padding-right:12px;white-space:nowrap}
+  #tip td.v{color:var(--ink);font-family:ui-monospace,Menlo,monospace;font-variant-numeric:tabular-nums;text-align:right}
+  #tip .reason{margin-top:7px;color:var(--amber);font-size:11.5px}
+  #tip .hint{margin-top:8px;padding-top:7px;border-top:1px solid var(--line);color:var(--t4);font-size:11px}
+
+  /* legend + states */
+  .legend{display:flex;gap:16px;flex-wrap:wrap;color:var(--t3);font-size:12px;margin:8px 2px 0}
+  .legend span{display:inline-flex;align-items:center;gap:6px}
+  .legend i{width:10px;height:10px;border-radius:50%}
+  .empty-state{border:1px dashed var(--line2);border-radius:var(--radius);padding:40px;text-align:center;color:var(--t3)}
+  .empty-state h3{color:var(--t2);margin:0 0 6px;font-size:15px}
+  .foot{margin-top:26px;color:var(--t4);font-size:11.5px;text-align:center}
+
+  @media (prefers-reduced-motion: reduce){
+    *{animation:none !important;transition:none !important}
+  }
+</style>
+</head>
+<body>
+<main>
+  <header class="top">
+    <div class="brand">
+      <div class="logo"><i></i></div>
+      <div>
+        <h1>BayWatch</h1>
+        <div class="sub">drive-bay health &amp; locator</div>
+      </div>
+    </div>
+    <div class="spacer"></div>
+    <div id="conn" class="conn"><span class="dot"></span><span id="connText">connecting</span></div>
+  </header>
+
+  <div class="fleetbar" id="fleetbar"></div>
+  <div id="hosts"></div>
+  <div class="legend">
+    <span><i style="background:var(--green);box-shadow:0 0 7px var(--green)"></i>healthy</span>
+    <span><i style="background:var(--amber);box-shadow:0 0 7px var(--amber)"></i>fault (ZFS / SMART)</span>
+    <span><i style="background:var(--blue);box-shadow:0 0 7px var(--blue)"></i>locate</span>
+    <span><i style="background:#333a49"></i>empty bay</span>
+    <span style="color:var(--t4)">click a bay to locate &middot; hover for drive detail</span>
+  </div>
+  <div class="foot mono" id="foot"></div>
+</main>
+
+<div id="tip"></div>
+
+<script>
+(() => {
+  "use strict";
+  const $ = (s, r=document) => r.querySelector(s);
+  const state = { hosts: [], locateDefault: 120, connected: false };
+  const ledColor = { healthy:"var(--green)", fault:"var(--amber)", empty:"#333a49", unknown:"var(--grey)" };
+
+  // ---- data helpers ----
+  const hostByName = n => state.hosts.find(h => h.host === n);
+  function upsertHost(h){
+    const i = state.hosts.findIndex(x => x.host === h.host);
+    if (i >= 0) state.hosts[i] = h; else state.hosts.push(h);
+    state.hosts.sort((a,b)=>a.host<b.host?-1:1);
+  }
+  function findSlot(host, encId, slotNo){
+    const h = hostByName(host); if(!h) return null;
+    for(const e of h.enclosures||[]) if(e.logical_id===encId)
+      for(const s of e.slots||[]) if(s.slot===slotNo) return {h,e,s};
+    return null;
+  }
+
+  // ---- rendering ----
+  function render(){
+    renderFleetbar();
+    const root = $("#hosts");
+    if(!state.hosts.length){
+      root.innerHTML = `<div class="empty-state"><h3>No host agents reporting</h3>
+        <div>Waiting for a bw-agent to connect. Check the agents are running on the Proxmox hosts.</div></div>`;
+      return;
+    }
+    root.innerHTML = "";
+    for(const h of state.hosts) root.appendChild(hostCard(h));
+    updateCountdowns();
+  }
+
+  function renderFleetbar(){
+    const drives = sum("drives"), faults = sum("faults"), locates = sum("locates"), empty = sum("empty");
+    const bar = $("#fleetbar");
+    bar.innerHTML = "";
+    bar.appendChild(chip(state.hosts.length, "hosts"));
+    bar.appendChild(chip(drives, "drives"));
+    bar.appendChild(chip(faults, "faults", faults>0?"warn":""));
+    bar.appendChild(chip(locates, "locating", locates>0?"loc":""));
+    bar.appendChild(chip(empty, "empty bays"));
+  }
+  const sum = k => state.hosts.reduce((a,h)=>a+(h[k]||0),0);
+  function chip(n, label, cls=""){
+    const d = document.createElement("div");
+    d.className = "chip "+cls;
+    d.innerHTML = `<b class="mono">${n}</b><span>${label}</span>`;
+    return d;
+  }
+
+  function hostCard(h){
+    const card = document.createElement("section");
+    card.className = "host";
+    const badge = h.online ? `<span class="badge up">online</span>` : `<span class="badge down">offline</span>`;
+    const seen = h.last_seen ? `updated ${rel(h.last_seen)}` : "";
+    card.innerHTML = `
+      <div class="hd">
+        <span class="name">${esc(h.host)}</span>
+        <span class="ctrl">${esc(h.controller||"")}</span>
+        ${badge}
+        <div class="spacer"></div>
+        <span class="mini"><b>${h.drives}</b> drives &middot;
+          <b style="color:${h.faults?'var(--amber)':'var(--t2)'}">${h.faults}</b> fault &middot;
+          <b style="color:${h.locates?'var(--blue)':'var(--t2)'}">${h.locates}</b> locating
+          <span class="seen mono" data-seen="${h.last_seen||''}"> &middot; ${seen}</span></span>
+      </div>`;
+    const body = document.createElement("div");
+    body.className = "body";
+    for(const e of h.enclosures||[]) body.appendChild(cageEl(h, e));
+    card.appendChild(body);
+    return card;
+  }
+
+  function cageEl(h, e){
+    const wrap = document.createElement("div");
+    wrap.className = "cage";
+    wrap.innerHTML = `<div class="lbl">${esc(e.label||e.id)} <span class="lid mono">${esc(e.logical_id||"")}</span></div>`;
+    const bays = document.createElement("div");
+    bays.className = "bays";
+    const slots = (e.slots||[]).slice().sort((a,b)=>a.slot-b.slot);
+    for(const s of slots) bays.appendChild(bayEl(h, e, s));
+    wrap.appendChild(bays);
+    return wrap;
+  }
+
+  function bayEl(h, e, s){
+    const b = document.createElement("button");
+    b.type = "button";
+    b.id = bayId(h.host, e.logical_id, s.slot);
+    applyBay(b, h, e, s);
+    b.addEventListener("mouseenter", ev => showTip(ev, b._slot.host, e.logical_id, s.slot));
+    b.addEventListener("mousemove", moveTip);
+    b.addEventListener("mouseleave", hideTip);
+    b.addEventListener("focus", ev => showTip(ev, b._slot.host, e.logical_id, s.slot, true));
+    b.addEventListener("blur", hideTip);
+    b.addEventListener("click", () => toggleLocate(h.host, e.logical_id, s));
+    return b;
+  }
+
+  function applyBay(b, h, e, s){
+    b._slot = { host:h.host, encId:e.logical_id, slot:s.slot, data:s };
+    let cls = "bay " + (s.state||"unknown");
+    if(s.locate) cls += " locate";
+    b.className = cls;
+    const cap = s.size ? esc(s.size) : (s.present ? "" : "empty");
+    const tempTxt = (s.temp_c>0) ? `${esc(String(s.temp_c))}&deg;` : "";
+    b.innerHTML = `
+      <div style="display:flex;justify-content:space-between;align-items:flex-start">
+        <span class="slotno mono">${s.slot}</span><span class="led"></span>
+      </div>
+      <div>
+        <div class="dev">${esc(s.dev||"—")}</div>
+        <div class="cap">${cap}${cap&&tempTxt?" · ":""}${tempTxt}</div>
+      </div>`;
+    const lbl = `bay ${s.slot}, ${s.present?(s.dev+" "+(s.state==='fault'?'FAULT':'healthy')):'empty'}${s.locate?', locating':''}`;
+    b.setAttribute("aria-label", lbl);
+    b.title = "";
+  }
+
+  function patchBay(host, encId, slot){
+    const f = findSlot(host, encId, slot.slot);
+    if(!f) { // structural change (new slot/host) - full render
+      return render();
+    }
+    const idx = f.e.slots.findIndex(x=>x.slot===slot.slot);
+    if(idx>=0) f.e.slots[idx] = slot; // replace in the model
+    const el = document.getElementById(bayId(host, encId, slot.slot));
+    if(el) applyBay(el, f.h, f.e, slot);
+  }
+
+  const bayId = (host, encId, slot) => `bay::${host}::${encId}::${slot}`;
+
+  // ---- locate ----
+  async function toggleLocate(host, encId, s){
+    const el = document.getElementById(bayId(host, encId, s.slot));
+    const seconds = s.locate ? 0 : state.locateDefault;
+    if(el) el.classList.add("pending");
+    try{
+      const r = await fetch("/api/locate", {
+        method:"POST", headers:{"Content-Type":"application/json"},
+        body: JSON.stringify({ host, enclosure_id:encId, slot:s.slot, seconds })
+      });
+      if(!r.ok) throw new Error(await r.text());
+    }catch(err){
+      console.error("locate failed", err);
+      flashFoot("locate failed: " + err.message);
+    }finally{
+      if(el) setTimeout(()=>el.classList.remove("pending"), 400);
+    }
+  }
+
+  // ---- tooltip ----
+  const tip = $("#tip");
+  function showTip(ev, host, encId, slotNo){
+    const f = findSlot(host, encId, slotNo); if(!f) return;
+    const s = f.s;
+    const color = s.fault ? "var(--amber)" : (s.present ? "var(--green)" : "#333a49");
+    const rows = [];
+    const add = (k,v)=>{ if(v!==undefined && v!==null && v!=="" && v!=="-") rows.push(`<tr><td class="k">${k}</td><td class="v">${esc(String(v))}</td></tr>`); };
+    add("Bay", `${f.e.label||f.e.id} · slot ${s.slot}`);
+    add("Device", s.dev);
+    add("Model", s.model);
+    add("Serial", s.serial);
+    add("Size", s.size);
+    add("Temp", s.temp_c>0 ? s.temp_c+" °C" : "");
+    add("SMART", s.smart);
+    add("ZFS", s.pool ? `${s.zfs} (${s.pool})` : s.zfs);
+    if(s.locate && s.locate_until) add("Locating", "ends "+rel(s.locate_until));
+    tip.innerHTML = `<div class="th"><span class="led" style="background:${color};box-shadow:0 0 8px ${color}"></span>
+        <b>${s.present ? esc(s.dev) : "Empty bay"}</b></div>
+      <table>${rows.join("")}</table>
+      ${s.reason?`<div class="reason">⚠ ${esc(s.reason)}</div>`:""}
+      <div class="hint">click to ${s.locate?"stop locating":"locate this bay"}</div>`;
+    tip.classList.add("show");
+    moveTip(ev);
+  }
+  function moveTip(ev){
+    const pad=14, w=tip.offsetWidth, h=tip.offsetHeight;
+    let x=ev.clientX+pad, y=ev.clientY+pad;
+    if(x+w>innerWidth-8) x=ev.clientX-w-pad;
+    if(y+h>innerHeight-8) y=ev.clientY-h-pad;
+    tip.style.left=x+"px"; tip.style.top=y+"px";
+  }
+  function hideTip(){ tip.classList.remove("show"); }
+
+  // ---- countdown ticker ----
+  function updateCountdowns(){
+    for(const h of state.hosts) for(const e of h.enclosures||[]) for(const s of e.slots||[]){
+      if(s.locate && s.locate_until){
+        const el = document.getElementById(bayId(h.host, e.logical_id, s.slot));
+        if(el){ const cap = el.querySelector(".cap"); const left = secsLeft(s.locate_until);
+          if(cap && left>0) cap.textContent = `locate ${left}s`; }
+      }
+    }
+    // refresh "updated Xs ago"
+    document.querySelectorAll(".seen").forEach(el=>{
+      const ts = el.getAttribute("data-seen"); if(ts) el.textContent = " · updated "+rel(ts);
+    });
+  }
+  setInterval(updateCountdowns, 1000);
+
+  // ---- connection ----
+  function setConn(live){
+    state.connected = live;
+    const c = $("#conn");
+    c.className = "conn " + (live?"live":"down");
+    $("#connText").textContent = live ? "live" : "reconnecting…";
+  }
+  function connect(){
+    const es = new EventSource("/api/stream");
+    es.addEventListener("fleet", e => { const f=JSON.parse(e.data); state.hosts=f.hosts||[]; render(); });
+    es.addEventListener("host", e => { upsertHost(JSON.parse(e.data).host); render(); });
+    es.addEventListener("slot", e => { const ev=JSON.parse(e.data); patchBay(ev.host, ev.enclosure_id, ev.slot);
+      const h=hostByName(ev.host); if(h) recount(h); renderFleetbar(); refreshHostMini(h); });
+    es.onopen = () => setConn(true);
+    es.onerror = () => setConn(false); // EventSource auto-reconnects
+  }
+  function recount(h){
+    let d=0,f=0,l=0,em=0;
+    for(const e of h.enclosures||[]) for(const s of e.slots||[]){
+      s.present?d++:em++; if(s.fault)f++; if(s.locate)l++;
+    }
+    h.drives=d;h.faults=f;h.locates=l;h.empty=em;
+  }
+  function refreshHostMini(h){
+    if(!h) return;
+    const card = [...document.querySelectorAll(".host")].find(c=>c.querySelector(".name")?.textContent===h.host);
+    if(!card) return;
+    const mini = card.querySelector(".mini");
+    if(mini) mini.innerHTML = `<b>${h.drives}</b> drives &middot;
+      <b style="color:${h.faults?'var(--amber)':'var(--t2)'}">${h.faults}</b> fault &middot;
+      <b style="color:${h.locates?'var(--blue)':'var(--t2)'}">${h.locates}</b> locating
+      <span class="seen mono" data-seen="${h.last_seen||''}"> &middot; updated ${rel(h.last_seen)}</span>`;
+  }
+
+  // ---- util ----
+  function esc(s){ return String(s).replace(/[&<>"]/g, c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c])); }
+  function secsLeft(iso){ return Math.max(0, Math.round((new Date(iso)-Date.now())/1000)); }
+  function rel(iso){
+    if(!iso) return "";
+    const d=(Date.now()-new Date(iso))/1000;
+    if(d<0) return Math.round(-d)+"s";
+    if(d<60) return Math.round(d)+"s ago";
+    if(d<3600) return Math.round(d/60)+"m ago";
+    return Math.round(d/3600)+"h ago";
+  }
+  let footTimer;
+  function flashFoot(msg){ const f=$("#foot"); f.textContent=msg; clearTimeout(footTimer); footTimer=setTimeout(()=>f.textContent="",4000); }
+
+  // ---- boot ----
+  fetch("/api/config").then(r=>r.json()).then(c=>{ if(c.locate_default) state.locateDefault=c.locate_default; }).catch(()=>{});
+  connect();
+})();
+</script>
+</body>
+</html>

--- a/apps/baywatch/ui/types.go
+++ b/apps/baywatch/ui/types.go
@@ -1,0 +1,88 @@
+package main
+
+import "time"
+
+// These mirror the bw-agent wire contract (apps/baywatch/agent/types.go). The
+// agent serves them; the UI consumes and re-aggregates them. Keep in sync.
+
+type Slot struct {
+	Slot        int        `json:"slot"`
+	Comp        string     `json:"comp"`
+	EnclosureID string     `json:"enclosure_id"`
+	Present     bool       `json:"present"`
+	State       string     `json:"state"`
+	Fault       bool       `json:"fault"`
+	Locate      bool       `json:"locate"`
+	LocateUntil *time.Time `json:"locate_until"`
+	Dev         string     `json:"dev"`
+	Model       string     `json:"model"`
+	Serial      string     `json:"serial"`
+	Size        string     `json:"size"`
+	TempC       int        `json:"temp_c"`
+	Smart       string     `json:"smart"`
+	Zfs         string     `json:"zfs"`
+	Pool        string     `json:"pool"`
+	Reason      string     `json:"reason"`
+}
+
+type Enclosure struct {
+	ID        string `json:"id"`
+	LogicalID string `json:"logical_id"`
+	Label     string `json:"label"`
+	Bays      int    `json:"bays"`
+	Slots     []Slot `json:"slots"`
+}
+
+// Snapshot is what an agent returns from /v1/enclosures and pushes as its first
+// SSE event.
+type Snapshot struct {
+	Host       string      `json:"host"`
+	Controller string      `json:"controller"`
+	TS         time.Time   `json:"ts"`
+	Enclosures []Enclosure `json:"enclosures"`
+}
+
+// SlotEvent is an incremental change pushed by an agent on /v1/stream.
+type SlotEvent struct {
+	Host        string `json:"host"`
+	EnclosureID string `json:"enclosure_id"`
+	Slot        Slot   `json:"slot"`
+}
+
+// --- UI aggregate types (what the browser consumes) ---
+
+// HostState is one host's view in the merged fleet, plus liveness metadata the
+// agent snapshot does not carry.
+type HostState struct {
+	Host       string      `json:"host"`
+	Controller string      `json:"controller"`
+	Online     bool        `json:"online"`
+	LastSeen   time.Time   `json:"last_seen"`
+	Enclosures []Enclosure `json:"enclosures"`
+	// summary counts for the header
+	Drives  int `json:"drives"`
+	Faults  int `json:"faults"`
+	Locates int `json:"locates"`
+	Empty   int `json:"empty"`
+}
+
+// Fleet is the full merged view returned by GET /api/fleet and pushed as the
+// first browser SSE event.
+type Fleet struct {
+	TS    time.Time   `json:"ts"`
+	Hosts []HostState `json:"hosts"`
+}
+
+// HostEvent is pushed to the browser when a host's liveness/snapshot changes.
+type HostEvent struct {
+	Host HostState `json:"host"`
+}
+
+// LocateRequest is the browser -> UI body for POST /api/locate, and the UI ->
+// agent body (minus Host) for the agent's POST /v1/locate.
+type LocateRequest struct {
+	Host        string `json:"host"`
+	EnclosureID string `json:"enclosure_id"`
+	Slot        int    `json:"slot"`
+	Seconds     int    `json:"seconds"`
+}

--- a/docs/drivebay-dashboard-plan.html
+++ b/docs/drivebay-dashboard-plan.html
@@ -1,0 +1,208 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BayWatch - Drive-Bay Health &amp; Locator - Plan</title>
+<style>
+  :root{
+    --bg:#0e1016; --panel:#161a23; --panel2:#1c212d; --ink:#e6e9ef; --mut:#9aa3b2;
+    --line:#262c3a; --green:#34d399; --amber:#f59e0b; --blue:#3b82f6; --grey:#4b5563;
+    --red:#ef4444; --acc:#7c9cff;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:15px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;}
+  main{max-width:780px;margin:0 auto;padding:42px 22px 90px}
+  h1{font-size:26px;margin:0 0 4px;letter-spacing:-.02em}
+  h2{font-size:19px;margin:38px 0 12px;padding-top:14px;border-top:1px solid var(--line);letter-spacing:-.01em}
+  h3{font-size:15px;margin:20px 0 6px;color:#c9d2e3}
+  p{margin:10px 0}
+  .sub{color:var(--mut);margin:0 0 18px}
+  code{background:#0b0d13;border:1px solid var(--line);border-radius:5px;padding:1px 6px;font:13px ui-monospace,SFMono-Regular,Menlo,monospace;color:#cbd5e1}
+  pre{background:#0b0d13;border:1px solid var(--line);border-radius:9px;padding:14px 16px;overflow:auto;font:12.5px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace;color:#cbd5e1}
+  .tag{display:inline-block;font-size:11px;font-weight:600;padding:2px 9px;border-radius:999px;border:1px solid var(--line);color:var(--mut);vertical-align:middle}
+  .tag.ok{color:var(--green);border-color:#1f5d47}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px 18px;margin:14px 0}
+  table{width:100%;border-collapse:collapse;margin:12px 0;font-size:13.5px}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--mut);font-weight:600}
+  .led{display:inline-block;width:11px;height:11px;border-radius:50%;margin-right:7px;vertical-align:middle;box-shadow:0 0 7px currentColor}
+  .g{color:var(--green);background:var(--green)} .a{color:var(--amber);background:var(--amber)}
+  .b{color:var(--blue);background:var(--blue)} .e{color:var(--grey);background:var(--grey);box-shadow:none}
+  ul{margin:8px 0;padding-left:22px} li{margin:5px 0}
+  details{background:var(--panel2);border:1px solid var(--line);border-radius:10px;padding:6px 14px;margin:12px 0}
+  summary{cursor:pointer;font-weight:600;padding:8px 0;color:#c9d2e3}
+  .grid{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  .pill{font-size:11px;color:var(--mut);border:1px solid var(--line);border-radius:6px;padding:1px 7px;margin-left:6px}
+  .who{font-size:11px;color:var(--acc);font-weight:600}
+  blockquote{margin:10px 0;padding:8px 14px;border-left:3px solid var(--acc);color:var(--mut);background:var(--panel2);border-radius:0 8px 8px 0}
+  .chassis{display:flex;gap:6px;flex-wrap:wrap;margin:8px 0}
+  .bay{width:30px;height:42px;border:1px solid var(--line);border-radius:4px;background:#0b0d13;display:flex;align-items:flex-end;justify-content:center;padding-bottom:4px;font-size:9px;color:var(--mut)}
+  .bay i{width:8px;height:8px;border-radius:50%;display:block}
+  hr{border:0;border-top:1px solid var(--line);margin:26px 0}
+  .small{font-size:12.5px;color:var(--mut)}
+  input[type=checkbox]{accent-color:var(--acc);margin-right:6px}
+</style>
+</head>
+<body>
+<main>
+
+<h1>BayWatch <span class="tag ok">PLAN</span></h1>
+<p class="sub">A self-hosted drive-bay health &amp; locator dashboard for the HPE Gen9 fleet (DL380 + DL360, Smart HBA / P440ar in HBA mode). Live LED-accurate chassis view, ZFS+SMART health, click-to-locate. Drafted from a three-model design pass (Codex - architecture, Gemini - UX/visualization, Cursor - risk/MVP), reconciled against the real hardware.</p>
+
+<div class="card">
+<strong>Where this came from.</strong> We already proved (live, on both servers) that the caddy <span class="led a"></span>amber fault and <span class="led b"></span>blue locate LEDs <em>are</em> controllable in HBA mode via the kernel SES interface, and a systemd health service is deployed that lights amber on unhealthy drives. This plan turns that proven engine into a real app with a web UI.
+</div>
+
+<h2>1 - The one constraint that shapes everything</h2>
+<p>The LED hardware lives on the <strong>bare-metal Proxmox hosts</strong>. The Kubernetes cluster runs as Talos <em>VMs on those hosts</em>, so a pod cannot see <code>/sys/class/enclosure</code> or <code>/dev/sg*</code>. Therefore the system is necessarily <strong>two-tier</strong>:</p>
+<pre>
+   browser ──https──&gt;  [ BayWatch UI ]                         (Kubernetes pod, *.iacob.uk)
+                         aggregator + SVG chassis + SSE
+                              │  LAN (Cilium → 192.168.1.x)
+              ┌───────────────┴────────────────┐
+        https/token                      https/token
+              ▼                                ▼
+   [ bw-agent @ DL380 ]              [ bw-agent @ DL360 ]       (systemd, root, bare metal)
+   owns SES + health + LEDs          owns SES + health + LEDs
+   /sys/class/enclosure, sg_ses      zpool, smartctl
+</pre>
+<p class="small">The agent is the only thing that touches hardware. The K8s app is a pretty, aggregating window onto the agents - if it dies, the health LEDs keep working.</p>
+
+<h2>2 - Key design decisions <span class="pill">the load-bearing ones</span></h2>
+
+<h3>D1 - Anchor bays on the SES element, not the block device <span class="who">(resolves Cursor's #1 risk)</span></h3>
+<p>Cursor's sharpest point: mapping a bay via its current <code>/dev/sdX</code> breaks exactly when a drive dies or is pulled - the moment you most need to find it. The hardware gives us a better anchor, and we <strong>verified it live</strong>:</p>
+<ul>
+<li>Every bay is a stable SES <strong>element</strong> with a fixed <code>slot</code> number, under an enclosure with a unique <code>logical_id</code> (e.g. <code>0x50014380435ccf80</code>).</li>
+<li>An <em>empty</em> bay still exists as a controllable element - we saw DL380 enc <code>2:0:8:0</code> slot 6 report <code>status: not installed</code> yet remain lightable. <strong>So we can locate a dead/pulled drive's bay.</strong></li>
+<li>The <code>slot</code> attribute also fixes the silkscreen mismatch we hit (elements 4-7 → physical slots 8,7,6,5).</li>
+</ul>
+<blockquote>Anchor = <code>(enclosure logical_id, slot)</code> for the bay/LED. Correlate the <em>drive</em> in it by serial/WWN for health + labels. A persisted <code>element ↔ last-seen serial</code> map means a vanished ZFS member still resolves to a physical bay.</blockquote>
+
+<h3>D2 - One writer per host owns all SES writes <span class="who">(resolves Cursor's concurrency race)</span></h3>
+<p>The current systemd health script and a locate feature would otherwise race on the same SES bits (health write clobbers the locate bit every 60s). Fix: <strong>fold health polling + locate into a single <code>bw-agent</code> daemon</strong> that holds desired LED state in memory and reconciles it atomically. The old timer/script is retired into the agent.</p>
+
+<h3>D3 - Security: LAN-bound, token-auth, writes limited to time-boxed locate <span class="who">(Cursor's #1 concern, pragmatic middle)</span></h3>
+<p>Cursor is right that a root HTTP daemon on the hypervisor is real attack surface. For a trusted home LAN the pragmatic stance:</p>
+<ul>
+<li>Agent binds to the host LAN IP only; bearer-token auth (shared secret in a K8s Secret).</li>
+<li>Reads are cheap; the <em>only</em> mutating endpoint is <code>locate</code>, and it is <strong>time-boxed</strong> (auto-clears, e.g. 60-300s) so nothing can pin a blue LED or wedge state.</li>
+<li>Fault/health LEDs are computed solely by the agent from ZFS+SMART - never settable from the network.</li>
+<li>Documented harder option for later: drop the HTTP write path entirely and have the pod invoke locate over an SSH forced-command key. <span class="small">(Deferred - token+LAN is enough for v1.)</span></li>
+</ul>
+
+<h3>D4 - The health engine stays independent of the UI</h3>
+<p>The agent's reconcile loop is self-contained: hardware truth = ZFS + SMART, evaluated on the host. The K8s app going down, or a network partition, never affects whether a failing drive shows amber. The UI degrades gracefully with a <em>data-freshness</em> badge.</p>
+
+<h2>3 - Visualization: generated SVG chassis <span class="who">(Gemini's rec, option A)</span></h2>
+<p>Three options weighed: (A) an SVG schematic generated from the real SES topology, (B) HPE product photos, (C) hybrid. <strong>Pick A.</strong> It is accurate (driven by live <code>slot</code> data), scalable, themeable to the glassmorphism Homepage vibe, and carries no copyright baggage. Photos can't map bays reliably and look wrong the moment a layout differs.</p>
+<p>Each bay is a cell that renders one of four states, hover = drive detail (model/serial/size/temp/SMART/ZFS vdev), click = locate toggle:</p>
+<div class="chassis">
+  <span class="bay"><i class="g"></i></span><span class="bay"><i class="g"></i></span>
+  <span class="bay"><i class="a"></i></span><span class="bay"><i class="g"></i></span>
+  <span class="bay"><i class="b"></i></span><span class="bay"><i class="g"></i></span>
+  <span class="bay"><i class="e"></i></span><span class="bay"><i class="g"></i></span>
+</div>
+<p class="small">
+<span class="led g"></span>healthy &nbsp; <span class="led a"></span>fault (ZFS/SMART) &nbsp; <span class="led b"></span>locate (pulsing) &nbsp; <span class="led e"></span>empty bay. Locate pulses; everything respects <code>prefers-reduced-motion</code>.
+</p>
+<p>The real fleet layout the SVG must render (discovered live):</p>
+<table>
+<tr><th>Server</th><th>Cages (enclosures)</th><th>Bays</th></tr>
+<tr><td>DL380 Gen9</td><td>3 × 8-bay front cages (H240, boxes 1-3) + 1 × 2-bay rear cage (H240ar)</td><td>25 populated / 26 slots (1 empty)</td></tr>
+<tr><td>DL360 Gen9</td><td>1 × 8-bay front cage (P440ar)</td><td>8</td></tr>
+</table>
+
+<h2>4 - Prior art <span class="who">(Gemini)</span></h2>
+<p>Nothing off-the-shelf does this combination (bay visualization + live SMART/ZFS + interactive locate + self-hosted homelab aesthetic, vendor-neutral over SES):</p>
+<table>
+<tr><th>Tool</th><th>Does</th><th>Gap for us</th></tr>
+<tr><td>ledmon / ledctl</td><td>SES/SGPIO fault+locate from mdraid</td><td>CLI only, mdraid-centric (we're ZFS), no UI</td></tr>
+<tr><td>TrueNAS enclosure view</td><td>Slick live bay map + identify</td><td>Locked to TrueNAS/iX hardware</td></tr>
+<tr><td>45Drives Houston</td><td>Cockpit-based disk UI</td><td>Proprietary, their chassis only</td></tr>
+<tr><td>HPE iLO / SSA</td><td>Native locate</td><td>SSA refuses LED control in HBA mode (we hit this)</td></tr>
+</table>
+<p class="small">Conclusion: a small custom app is justified - the value is the vendor-neutral SES path + your exact fleet + your aesthetic.</p>
+
+<h2>5 - Shape of the build <span class="who">(Codex, trimmed to Cursor's MVP)</span></h2>
+<h3>Stack</h3>
+<ul>
+<li><strong>bw-agent</strong>: single static <strong>Go</strong> binary + systemd unit. No runtime deps, trivial to drop on Proxmox. Reconcile loop (poll ZFS+SMART, diff, apply SES), REST + SSE, token auth.</li>
+<li><strong>bw-ui</strong>: single <strong>Go</strong> binary serving an embedded SVG/JS frontend (one container image, app-template friendly). Aggregates agents over the LAN, streams changes to the browser via SSE. Deployed via bjw-s <code>app-template</code> HelmRelease + Gateway API HTTPRoute on <code>baywatch.iacob.uk</code> (envoy-internal), optionally behind Authentik.</li>
+</ul>
+<h3>"Events from the controller"</h3>
+<p>SES has no push. The agent fast-polls (~2-5s), diffs, and emits only <em>changes</em> upstream over SSE; a <code>udev</code> watch triggers an immediate refresh on drive insert/remove. To the browser it feels event-driven.</p>
+<details>
+<summary>API sketch</summary>
+<pre>bw-agent
+  GET  /v1/enclosures        → cages, slots, drive identity, health, led state
+  GET  /v1/stream            → SSE: {slot, state} change events
+  POST /v1/locate            → {enclosure_id, slot, seconds} (time-boxed, auto-clear)
+  GET  /v1/healthz
+bw-ui (K8s)
+  GET  /api/fleet            → merged snapshot of both agents
+  GET  /api/stream           → fan-in SSE to browser
+  POST /api/locate           → proxied to the owning agent</pre>
+</details>
+
+<h2>6 - Phasing</h2>
+<h3>MVP <span class="pill">~1 week, real value, low blast radius</span></h3>
+<ul>
+<li><input type="checkbox"> <code>bw-agent</code> on both hosts: reconcile health→amber (port the proven logic), expose read API + SSE, one time-boxed <code>locate</code> endpoint, token auth, LAN-bound.</li>
+<li><input type="checkbox"> Persist the <code>(enclosure_id, slot) ↔ serial</code> map; handle empty/missing bays.</li>
+<li><input type="checkbox"> <code>bw-ui</code>: read-only live SVG chassis for both servers, hover details, click-to-locate with countdown.</li>
+<li><input type="checkbox"> Deploy <code>bw-ui</code> via app-template at <code>baywatch.iacob.uk</code>; add to Homepage.</li>
+</ul>
+<h3>v1</h3>
+<ul>
+<li><input type="checkbox"> udev hot-plug, locate leases + conflict handling, data-freshness badges, audit log of LED writes.</li>
+<li><input type="checkbox"> Drive detail drawer (temp trend, SMART attributes, ZFS vdev/pool), per-cage health summary.</li>
+</ul>
+<h3>v2 <span class="pill">defer unless wanted</span></h3>
+<ul>
+<li><input type="checkbox"> Authentik SSO, mTLS or SSH-forced-command write path, Prometheus metrics, alert routing, "blink-on-failure" auto-locate.</li>
+</ul>
+
+<h2>7 - Risks carried forward <span class="who">(Cursor)</span></h2>
+<table>
+<tr><th>#</th><th>Risk</th><th>Mitigation in this plan</th></tr>
+<tr><td>1</td><td>Root daemon attack surface on hypervisor</td><td>D3: LAN-bound, token, writes = time-boxed locate only; SSH option later</td></tr>
+<tr><td>2</td><td>Mapping breaks on pulled/dead drive</td><td>D1: anchor on SES element/slot (proven to persist when empty)</td></tr>
+<tr><td>3</td><td>Health vs locate SES write race</td><td>D2: single-writer agent, atomic reconcile</td></tr>
+<tr><td>4</td><td>Stale UI hiding a real failure</td><td>D4: health independent of UI + freshness badge</td></tr>
+<tr><td>5</td><td>SES LED state lost on enclosure power loss</td><td>Documented limitation; agent re-asserts on boot</td></tr>
+</table>
+
+<h2>8 - Decisions for Andrei</h2>
+<ul>
+<li><strong>Name</strong>: "BayWatch" (placeholder) - keep or rename?</li>
+<li><strong>Scope now</strong>: build the MVP, or stop at this plan?</li>
+<li><strong>Auth</strong>: leave behind envoy-internal only, or wire Authentik SSO from day one?</li>
+<li><strong>Locate default timeout</strong>: 60s? 5min?</li>
+</ul>
+
+<details>
+<summary>Appendix - live fleet topology snapshot (reference for the SVG layout)</summary>
+<pre>DL380G9
+  enc 0:0:3:0 (H240ar, rear cage)  logical_id 0x50014380431497d0
+     slot3=sda  slot4=sdb
+  enc 1:0:9:0 (H240, box)          logical_id 0x50014380435cc910
+     slot1..8 = sdc sdd sde sdf / sdj sdi sdh sdg
+  enc 2:0:8:0 (H240, box)          logical_id 0x50014380435ccf80
+     slot1..8 = sdk sdl sdm sdn / sdq sdp [EMPTY] sdo
+  enc 3:0:9:0 (H240, box)          logical_id 0x50014380435cc940
+     slot1..8 = sdr sds sdt sdu / sdy sdx sdw sdv
+DL360G9
+  enc 0:0:9:0 (P440ar)             logical_id 0x5001438034cae4a0
+     slot1..8 = sda sdb sdc sdd sde sdf sdg sdh
+(note: within each 8-bay cage, SES element index 4-7 maps to physical slots 8,7,6,5)</pre>
+</details>
+
+<hr>
+<p class="small">Generated engine already live: <code>/usr/local/sbin/drive-health-leds.sh</code> + systemd timer on both hosts. This plan supersedes that script by folding it into <code>bw-agent</code>.</p>
+
+</main>
+</body>
+</html>

--- a/kubernetes/apps/default/homepage/app/configmap.yaml
+++ b/kubernetes/apps/default/homepage/app/configmap.yaml
@@ -581,6 +581,10 @@ data:
           icon: scrutiny.svg
           href: https://scrutiny.iacob.uk
           description: SMART disk monitoring
+      - BayWatch:
+          icon: mdi-harddisk
+          href: https://baywatch.iacob.uk
+          description: Drive-bay LEDs & locate
       - Plausible:
           icon: plausible.svg
           href: https://plausible.iacob.co.uk

--- a/kubernetes/apps/monitoring/baywatch/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/baywatch/app/helmrelease.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: baywatch
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: baywatch
+  interval: 1h
+  values:
+    controllers:
+      baywatch:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/andrei-iacobb/baywatch
+              tag: latest
+            env:
+              BW_BIND: ":8080"
+              # Each bw-agent on a bare-metal Proxmox host (LAN, token-auth).
+              BW_AGENTS: "DL380G9=http://192.168.1.150:9099,DL360G9=http://192.168.1.100:9099"
+              BW_LOCATE_DEFAULT: "120"
+              BW_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: baywatch-secret
+                    key: BW_TOKEN
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 2
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 64Mi
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      app:
+        ports:
+          http:
+            port: 8080
+    route:
+      app:
+        hostnames: ["baywatch.iacob.uk"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8080

--- a/kubernetes/apps/monitoring/baywatch/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/baywatch/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./secret.sops.yaml
+  - ./pull-secret.sops.yaml

--- a/kubernetes/apps/monitoring/baywatch/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/baywatch/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: baywatch
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/monitoring/baywatch/app/pull-secret.sops.yaml
+++ b/kubernetes/apps/monitoring/baywatch/app/pull-secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghcr-pull-secret
+  namespace: monitoring
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: ENC[AES256_GCM,data:PhRr9KVDvmMLjmabdK4Rt03YLbpTGbAQ0dMjiRAYWSf4zWif2QEtPQ8mQUSbTlr7rFw17xiTQmpmmO7ltfaCRt8xWMyZ0hF/5UC9fDPLGmyPhH/8yt3uKZAsh87EEBDswhKcrCS57ofgsC1+r2uoOkoYwOpikurXKybnYEtF3Z4n6yFac+lrv1myJbmaQyO4oEHuRj2UdoS/0k0rhfNMUy3vgh0+Vp/T2yf/ThTgz7KxwG7xzmrzxf29vg==,iv:FmduJ+sNSdegvqdApMBw1z0Bpoy8Im6TavAJnSmxJ7w=,tag:fTPYy8BfJifvLLueb4W/zg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBteFBYWVNzUHAvTmIzZGlY
+        TjYrWG1URkMrenlnNExhclhtZ2xoK2poNHpRCnBEWENBM2c2Yk9aNVV6OWs3N3pO
+        YjZsUHlpY2ttNjBsN3RGQ3Z2UkhmUW8KLS0tIHN5b1gwUDlYKzlXOW5BNXNGMmhn
+        TWtUN0xkY0Q1MHFxaHV5VXJVUkZSR0EKXQ8LeP2Pf3NwWVwgcEnlV2hbYmoJhI3E
+        hIO+gQ0D6n+9pJXpYdkTdOGPa1xK3w8cvha07UT0stKBlTHrR5n2Tw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eer8sfrzmafe78ts498r449cu709g500zfw4pemhptac8rqpwq9qkxm0yq
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-26T19:53:31Z"
+  mac: ENC[AES256_GCM,data:bdgz0JnCRCbn2wk+D57cDwllyQNTG1VcYfcoDbnV6gqo2qj+EEI/gKkEN1YDE9ct9gHoAJ77ePFYVW0RaK0QikDOAjlAzGUdTRxhTJZPCXR7ZMJNAiBgRHRlY1k2r63zITQKN54/WVYqRj1Krgx7loJIF1wj3oq3c0julM/kOXM=,iv:ong5cm+m0QIisNEOyLRv6dIfE1f6hD6wl+RLFLnliOA=,tag:Go7vGUQ5s6w9DmvbDK2LfQ==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.1

--- a/kubernetes/apps/monitoring/baywatch/app/secret.sops.yaml
+++ b/kubernetes/apps/monitoring/baywatch/app/secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: baywatch-secret
+  namespace: monitoring
+type: Opaque
+stringData:
+  BW_TOKEN: ENC[AES256_GCM,data:OFAF1ABQYEBR7H7vqj+5m9/XGfzsRZs5Iprr+W4y9L3CgvsCpmWRUDURL2/qm82g,iv:TkNooyWCgEvt8yBNUd60lyGmZf7/KM6NNeRJw+lFXCI=,tag:5haiPD51d9Z4P6UNZ2YpLw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiQUpEeXhyN210RWlwVjVC
+        ekVlQ2VBblVrV3c1clRGRFptaU1uMUozeDNRCkVveVhHMEdUSmEzVFBZc0VybnJ3
+        WmYwUDNqVUg1cFgrTUV1Qms3ejlxOHcKLS0tIG9OMVNVYy9RL2lnUzByd1dpZlps
+        Uk1DYzJnMlhwUUxWRmhiZTJudmdkaFEKTVlQrUaZoUCxHTwq4K58vvj8W78r1xA9
+        KkamUoLc+jq3HvcjS6CmqDlUTK4PgNVPREqwQgoTcfsWDiOxddHqbQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eer8sfrzmafe78ts498r449cu709g500zfw4pemhptac8rqpwq9qkxm0yq
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-06-26T19:53:31Z"
+  mac: ENC[AES256_GCM,data:1/gw+73cLmk2qBMEYD9IUQt9vI2uQ1pWJD/1teH3R3Omvi6MWQfelfVF24rbWOfIQBeWR79XBGdGASlNIBY36JalwC4k3ZzoA7dIjlkfSBrNfPfbdeHmo9VXSRxQShVYhsOi7SbLaRQuDMxW9Rk/G6dfuAr5hpliWf0J6dMPpsI=,iv:HEaj5lZjrmua9tRWWPFIPtuxWP8A1NSw34v4zR6LN7E=,tag:ag598QFL0NkfQG7KaaD5kQ==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.1

--- a/kubernetes/apps/monitoring/baywatch/ks.yaml
+++ b/kubernetes/apps/monitoring/baywatch/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: baywatch
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/monitoring/baywatch/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: monitoring
+  wait: false

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -17,4 +17,5 @@ resources:
   - alloy/ks.yaml
   - uptime-kuma/ks.yaml
   - scrutiny/ks.yaml
+  - baywatch/ks.yaml
   # - graphite-exporter/ks.yaml


### PR DESCRIPTION
Two-tier drive-bay health + locator. `bw-agent` (systemd, root) is the single writer of the SES caddy LEDs on each Proxmox host (amber=ZFS/SMART fault, time-boxed blue=locate); `bw-ui` aggregates both agents and serves a live SVG-chassis frontend at baywatch.iacob.uk with click-to-locate.

Verified live on DL380 (25 drives/4 cages) + DL360 (8 drives): topology/health/temps correct, locate physically lights/clears the caddy LED browser->agent->sysfs. Cross-reviewed by codex/gemini/cursor; CRITICAL findings (unbounded body, XSS) fixed. Retires the old drive-health-leds.timer.