### PR TITLE
chore(baywatch): inline favicon + head meta

### DIFF
--- a/apps/baywatch/ui/static/index.html
+++ b/apps/baywatch/ui/static/index.html
@@ -4,6 +4,12 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>BayWatch - drive bay health</title>
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='7' fill='%230c0e14'/><rect x='9' y='5' width='14' height='22' rx='2' fill='none' stroke='%233b82f6' stroke-width='1.5'/><circle cx='16' cy='22' r='2.4' fill='%2334d399'/></svg>">
+<meta name="theme-color" content="#0c0e14">
+<meta name="color-scheme" content="dark">
+<meta name="robots" content="noindex">
+<meta name="description" content="Live drive-bay health and locator for the HPE Gen9 fleet">
+
 <style>
   :root{
     --bg:#0c0e14; --panel:rgba(22,26,35,.72); --panel2:#1c212d; --ink:#e8ebf2;


### PR DESCRIPTION
Adds an inline SVG favicon, theme-color, and noindex to the BayWatch UI - silences the /favicon.ico 404.