### PR TITLE
feat(baywatch): drive green healthy LED via sg_ses OK bit

### DIFF
--- a/apps/baywatch/README.md
+++ b/apps/baywatch/README.md
@@ -24,9 +24,15 @@ writer** of every caddy LED (it replaces the old `drive-health-leds.timer`).
 ## Components
 
 - `agent/` - `bw-agent`, a dependency-free static Go daemon. Reconcile loop reads
-  SES sysfs + `zpool status` + `smartctl`, drives the amber fault LED (ZFS not
-  ONLINE / errors, or SMART failing) and the blue locate LED (time-boxed), writing
-  sysfs only on change. Serves REST + SSE on `:9099` with bearer-token auth.
+  SES topology (sysfs) + `zpool status` + `smartctl`, and drives the caddy LEDs via
+  `sg_ses` on the enclosure's scsi_generic device:
+  - **green** (`ok` bit) - drive present & healthy
+  - **amber** (`fault` bit) - ZFS not-ONLINE / errors, or SMART failing
+  - **blue** (`ident` bit) - time-boxed locate
+  It diffs against last-applied state and only shells out on a real change (plus a
+  full-sync on start and a periodic re-assert). NOTE: contrary to common forum
+  folklore, the HPE Gen9 H240 / P440ar backplanes *do* honor `sg_ses --set=ok`
+  (green) in HBA mode - verified live. Serves REST + SSE on `:9099`, bearer auth.
 - `ui/` - `bw-ui`, a static Go binary that aggregates both agents over the LAN,
   serves the embedded SVG-chassis frontend (`ui/static/index.html`), fans changes
   to browsers over SSE, and proxies time-boxed locate requests.

--- a/apps/baywatch/agent/main.go
+++ b/apps/baywatch/agent/main.go
@@ -62,7 +62,17 @@ type agent struct {
 	cur         *Snapshot            // latest published snapshot
 	locateUntil map[string]time.Time // compKey -> expiry
 
+	applied map[string]ledState // compKey -> last LED state written to hardware
+	cycle   int                 // reconcile counter (for full-sync / re-assert)
+
 	kick chan struct{} // request an immediate reconcile
+}
+
+// ledState is the bi-color/locate state the agent has driven onto a bay.
+type ledState struct {
+	ok    bool // green - present & healthy
+	fault bool // amber - ZFS/SMART fault
+	ident bool // blue  - locate
 }
 
 func main() {
@@ -78,6 +88,7 @@ func main() {
 		health:      newHealthCache(),
 		hub:         newHub(),
 		locateUntil: map[string]time.Time{},
+		applied:     map[string]ledState{},
 		kick:        make(chan struct{}, 1),
 	}
 
@@ -167,6 +178,12 @@ func (a *agent) reconcile() {
 	healthByDev := a.health.snapshot(devsOf(comps))
 	now := time.Now()
 
+	// fullSync (first cycle) writes every bit so any stale LED is corrected;
+	// reassert (every ~60s) re-affirms the desired "on" bits to heal drift.
+	fullSync := a.cycle == 0
+	reassert := a.cycle%20 == 0
+	a.cycle++
+
 	// Build enclosure grouping + friendly labels (rear vs numbered front boxes).
 	encOrder := []string{}        // enclosure names in stable order
 	encComps := map[string][]int{} // encName -> indexes into comps
@@ -215,24 +232,18 @@ func (a *agent) reconcile() {
 				bad, reason = dh.bad()
 			}
 
-			// Desired LED state, then write only on change (single writer).
+			// Desired bi-color/locate state for this bay:
+			//   green (ok)  = drive present and healthy
+			//   amber(fault)= drive present and unhealthy
+			//   blue (ident)= a time-boxed locate is active
+			// The agent is the single writer; we diff against the last-applied
+			// state and only shell out to sg_ses on a real change (plus the
+			// full-sync / periodic re-assert), so the backplane is never spammed.
 			desiredFault := bad
+			desiredOK := present && !bad
 			desiredLocate := a.locateActive(key, now)
-			if c.fault != desiredFault {
-				if e := setFault(c.compDir, desiredFault); e != nil {
-					log.Printf("setFault %s slot %d: %v", name, c.slot, e)
-				} else {
-					log.Printf("fault %s slot %d (%s) -> %v %s", name, c.slot, devOr(c.dev), desiredFault, reason)
-					c.fault = desiredFault
-				}
-			}
-			if c.locate != desiredLocate {
-				if e := setLocate(c.compDir, desiredLocate); e != nil {
-					log.Printf("setLocate %s slot %d: %v", name, c.slot, e)
-				} else {
-					c.locate = desiredLocate
-				}
-			}
+			want := ledState{ok: desiredOK, fault: desiredFault, ident: desiredLocate}
+			a.applyLEDs(c, want, fullSync, reassert, reason)
 
 			state := StateHealthy
 			switch {
@@ -283,6 +294,34 @@ func (a *agent) reconcile() {
 
 	for _, ev := range events {
 		a.hub.pub(sseFrame("slot", ev))
+	}
+}
+
+// applyLEDs drives the green/amber/blue bits for one bay via sg_ses, writing a
+// bit only when it changes (plus full-sync on first cycle and a periodic
+// re-assert of the "on" bits to heal drift). On a write error it keeps the old
+// applied value so the next cycle retries.
+func (a *agent) applyLEDs(c *rawComp, want ledState, fullSync, reassert bool, reason string) {
+	key := compKey(c.logicalID, c.slot)
+	prev := a.applied[key]
+	apply := func(field string, was, w bool) bool {
+		if w == was && !fullSync && !(reassert && w) {
+			return was
+		}
+		if err := setLED(c.sgDev, c.slot, field, w); err != nil {
+			log.Printf("setLED %s slot %d %s=%v: %v", c.encName, c.slot, field, w, err)
+			return was // retry next cycle
+		}
+		if w != was {
+			log.Printf("led %s slot %d (%s) %s -> %v %s", c.encName, c.slot, devOr(c.dev), field, w, reason)
+		}
+		return w
+	}
+	// Clear green before asserting amber (and vice-versa) by ordering ok first.
+	a.applied[key] = ledState{
+		ok:    apply(ledOK, prev.ok, want.ok),
+		fault: apply(ledFault, prev.fault, want.fault),
+		ident: apply(ledIdent, prev.ident, want.ident),
 	}
 }
 

--- a/apps/baywatch/agent/ses.go
+++ b/apps/baywatch/agent/ses.go
@@ -2,35 +2,44 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 )
 
-// enclosureRoot is the kernel SCSI Enclosure Services sysfs interface. Each
-// enclosure exposes per-bay component dirs with fault/locate/status/slot files
-// and a `device/block/<sdX>` symlink to the installed drive. We proved live on
-// the HPE Gen9 H240/P440ar backplanes that writing these files physically drives
-// the caddy LEDs even in HBA mode (where ssacli refuses).
+// enclosureRoot is the kernel SCSI Enclosure Services sysfs interface. We read
+// topology (slot, status, installed block device, enclosure logical_id) from
+// here. LED control, however, goes through sg_ses against the enclosure's
+// scsi_generic device, because the GREEN/"OK" state has no sysfs file - only
+// fault/locate do. We proved live on the HPE Gen9 H240/P440ar backplanes (HBA
+// mode) that sg_ses --set=ok lights GREEN, --set=fault lights AMBER, and
+// --set=ident lights BLUE, despite ssacli refusing LED control in HBA mode and
+// the common "green is impossible in HBA mode" folklore.
 const enclosureRoot = "/sys/class/enclosure"
 
-// rawComp is a discovered SES element (one physical bay) plus its live sysfs state.
+// SES Array Device Slot control fields we drive (sg_ses acronyms).
+const (
+	ledOK    = "ok"    // green  - drive present & healthy
+	ledFault = "fault" // amber  - ZFS/SMART fault
+	ledIdent = "ident" // blue   - locate / identify
+)
+
+// rawComp is a discovered SES element (one physical bay) plus the sg device that
+// controls its LEDs.
 type rawComp struct {
 	encName   string // sysfs enclosure dir, e.g. 2:0:8:0
 	logicalID string // enclosure logical_id, e.g. 0x50014380435ccf80
-	compDir   string // absolute path to the component dir
+	sgDev     string // this enclosure's SES device, e.g. /dev/sg13
 	comp      string // basename, e.g. ArrayElement0006
-	slot      int    // SES slot number
+	slot      int    // SES slot number (and sg_ses --dev-slot-num)
 	status    string // OK | not installed | ...
-	fault     bool   // current fault sysfs bit
-	locate    bool   // current locate sysfs bit
 	dev       string // installed block device basename, e.g. sdk ("" if empty)
 }
 
 // readEnclosures walks the SES sysfs tree and returns every bay across every
-// controller on this host. Reads are cheap (pure sysfs), so the reconcile loop
-// can call this every cycle.
+// controller on this host, including the sg device used to drive its LEDs.
 func readEnclosures() ([]rawComp, error) {
 	encDirs, err := os.ReadDir(enclosureRoot)
 	if err != nil {
@@ -41,6 +50,7 @@ func readEnclosures() ([]rawComp, error) {
 		encName := e.Name()
 		encPath := filepath.Join(enclosureRoot, encName)
 		logicalID := strings.TrimSpace(readFile(filepath.Join(encPath, "id")))
+		sgDev := resolveSgDev(encPath)
 
 		comps, err := os.ReadDir(encPath)
 		if err != nil {
@@ -50,7 +60,7 @@ func readEnclosures() ([]rawComp, error) {
 			compDir := filepath.Join(encPath, c.Name())
 			slotStr := readFile(filepath.Join(compDir, "slot"))
 			if slotStr == "" {
-				continue // not a bay component (e.g. enclosure/power/temp elements)
+				continue // not a bay component (enclosure/power/temp elements)
 			}
 			slot, err := strconv.Atoi(strings.TrimSpace(slotStr))
 			if err != nil {
@@ -59,14 +69,11 @@ func readEnclosures() ([]rawComp, error) {
 			rc := rawComp{
 				encName:   encName,
 				logicalID: logicalID,
-				compDir:   compDir,
+				sgDev:     sgDev,
 				comp:      c.Name(),
 				slot:      slot,
 				status:    strings.TrimSpace(readFile(filepath.Join(compDir, "status"))),
-				fault:     sysfsBitOn(readFile(filepath.Join(compDir, "fault"))),
-				locate:    sysfsBitOn(readFile(filepath.Join(compDir, "locate"))),
 			}
-			// device/block/<sdX> -> installed drive
 			blockDir := filepath.Join(compDir, "device", "block")
 			if entries, err := os.ReadDir(blockDir); err == nil && len(entries) > 0 {
 				rc.dev = entries[0].Name()
@@ -83,31 +90,29 @@ func readEnclosures() ([]rawComp, error) {
 	return out, nil
 }
 
-// setFault commands the amber fault LED. We only ever write on a real change
-// (the caller diffs), so this never spams the backplane.
-func setFault(compDir string, on bool) error {
-	return writeBit(filepath.Join(compDir, "fault"), on)
-}
-
-// setLocate commands the blue locate/identify LED.
-func setLocate(compDir string, on bool) error {
-	return writeBit(filepath.Join(compDir, "locate"), on)
-}
-
-func writeBit(path string, on bool) error {
-	v := "0"
-	if on {
-		v = "1"
+// resolveSgDev finds the scsi_generic device for an enclosure, e.g.
+// /sys/class/enclosure/1:0:9:0/device/scsi_generic/sg13 -> /dev/sg13.
+func resolveSgDev(encPath string) string {
+	dir := filepath.Join(encPath, "device", "scsi_generic")
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) == 0 {
+		return ""
 	}
-	return os.WriteFile(path, []byte(v), 0)
+	return "/dev/" + entries[0].Name()
 }
 
-// sysfsBitOn normalizes the enclosure LED files. The kernel enclosure driver
-// reads a "fault" of 1 back as 6 (it ORs in the FAULT_SENSED/REQSTD bits), and
-// trailing newlines are common - so treat any nonzero as on.
-func sysfsBitOn(s string) bool {
-	s = strings.TrimSpace(s)
-	return s != "" && s != "0"
+// setLED drives one bi-color/locate state on one bay via sg_ses. field is one of
+// ledOK / ledFault / ledIdent. Callers diff against last-applied state so this
+// only runs on a real change (plus a periodic re-assert), never per-cycle spam.
+func setLED(sgDev string, slot int, field string, on bool) error {
+	if sgDev == "" {
+		return nil
+	}
+	flag := "--clear=" + field
+	if on {
+		flag = "--set=" + field
+	}
+	return exec.Command("sg_ses", "--dev-slot-num="+strconv.Itoa(slot), flag, sgDev).Run()
 }
 
 func readFile(path string) string {
@@ -120,8 +125,8 @@ func readFile(path string) string {
 
 // cageLabel derives a friendly label for a cage. The HPE silkscreen box number
 // is not exposed over SES, so we label rear 2-bay cages explicitly and number
-// the front 8-bay cages 1..N in stable logical_id order. order is the cage index
-// among same-size cages.
+// the front 8-bay cages 1..N in stable order. order is the cage index among
+// same-size cages.
 func cageLabel(bays, order int) string {
 	switch {
 	case bays <= 2:


### PR DESCRIPTION
Healthy drives now show solid GREEN on the physical caddy, faulted ones amber, locate blue - all via sg_ses. The Gen9 backplanes honor `--set=ok` in HBA mode despite forum folklore saying otherwise (verified live on both servers). Agent switched from sysfs to sg_ses LED control with single-writer diffing + full-sync + periodic re-assert.